### PR TITLE
Replace lxml with BeautifulSoup4 and html5lib

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,9 +38,17 @@ draftjs_exporter documentation
 ### Limitations of `lxml`
 
 - Succinct documentation (http://lxml.de/tutorial.html is the best)
-- XML parser first, not really meant to build HTML
-- No support for document fragments
-- No support for text nodes (`elt.text` and `elt.tail` attributes instead)
+- XML parser first, not really meant to build HTML.
+- No support for document fragments.
+- No support for text nodes (`elt.text` and `elt.tail` attributes instead).
+
+### Limitations of `html5lib`
+
+- Generated HTML is always "made valid" by being wrapped in '<html><head></head><body></body></html>'.
+
+### Limitations of `BeautifulSoup4`
+
+- The API to parse/generate HTML is clunky.
 
 #### Constraints (to be weighted)
 

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -4,6 +4,13 @@ import re
 
 from bs4 import BeautifulSoup
 
+# Python 2/3 unicode compatibility hack.
+# See http://stackoverflow.com/questions/6812031/how-to-make-unicode-string-with-python3
+try:
+    UNICODE_EXISTS = bool(type(unicode))
+except NameError:
+    unicode = lambda s: str(s)
+
 
 def Soup(str):
     """
@@ -107,7 +114,7 @@ class DOM(object):
         better way to do this.
         Dirty, but quite easy to understand.
         """
-        return re.sub(r'</?(fragment|textnode|body|html|head)>', '', str(Soup(str(elt).decode('utf-8'))).decode('utf-8')).strip()
+        return re.sub(r'</?(fragment|textnode|body|html|head)>', '', unicode(Soup(unicode(elt)))).strip()
 
     @staticmethod
     def pretty_print(markup):

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -107,7 +107,7 @@ class DOM(object):
         better way to do this.
         Dirty, but quite easy to understand.
         """
-        return re.sub(r'</?(fragment|textnode|body|html|head)>', '', unicode(Soup(unicode(elt)))).strip()
+        return re.sub(r'</?(fragment|textnode|body|html|head)>', '', str(Soup(str(elt).decode('utf-8'))).decode('utf-8')).strip()
 
     @staticmethod
     def pretty_print(markup):

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -43,10 +43,9 @@ class DOM(object):
 
             for key in props:
                 prop = props[key]
-                # Filter null values and cast to string for lxml.
-                # TODO Is this still necessary with BeautifulSoup / html5lib?
+                # Filter None values.
                 if prop is not None:
-                    attributes[key] = str(prop)
+                    attributes[key] = prop
 
             elt = DOM.create_tag(type, attributes)
 

--- a/example.py
+++ b/example.py
@@ -1,4 +1,8 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import, unicode_literals
+
+import codecs
 
 from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
@@ -69,7 +73,7 @@ content_state = {
         },
         {
             'key': '5384u',
-            'text': 'Everyone at Springload applies the best principles of UX to their work.',
+            'text': 'Everyone 🍺 Springload applies the best principles of UX to their work.',
             'type': 'blockquote',
             'depth': 0,
             'inlineStyleRanges': [],
@@ -262,5 +266,5 @@ markup = exporter.render(content_state)
 print(DOM.pretty_print(markup))
 
 # Output to a file
-with open('example.html', 'w') as file:
-    file.write(markup)
+with codecs.open('example.html', 'w', 'utf-8') as file:
+    file.write('<meta charset="utf-8" />' + markup)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ except ImportError:
 
 
 install_requires = [
-    'lxml>=3.6.0',
+    'beautifulsoup4>=4.4.1',
+    'html5lib==0.999999',
 ]
 
 # Testing dependencies

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 install_requires = [
     'beautifulsoup4>=4.4.1',
-    'html5lib==0.999999',
+    'html5lib>=0.999,<=0.9999999',
 ]
 
 # Testing dependencies

--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -15,7 +15,7 @@ class TestDOM(unittest.TestCase):
         self.assertEqual(DOM.get_tag_name(DOM.create_element()), 'fragment')
 
     def test_create_element_nested(self):
-        self.assertEqual(DOM.render(DOM.create_element('a', {}, DOM.create_element('span', {'className': 'file-info icon-text'}, DOM.create_element('span', {'className': 'icon-text__text'}, 'Test test'), DOM.create_element('svg', {'className': 'icon'}, DOM.create_element('use', {'xlink:href': '#icon-test'}))))), '<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xmlns:ns0="http://www.w3.org/1999/xlink" ns0:href="#icon-test"></use></svg></span></a>')
+        self.assertEqual(DOM.render(DOM.create_element('a', {}, DOM.create_element('span', {'className': 'file-info icon-text'}, DOM.create_element('span', {'className': 'icon-text__text'}, 'Test test'), DOM.create_element('svg', {'className': 'icon'}, DOM.create_element('use', {'xlink:href': '#icon-test'}))))), '<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xlink:href="#icon-test"></use></svg></span></a>')
 
     def test_create_document_fragment(self):
         self.assertEqual(DOM.get_tag_name(DOM.create_document_fragment()), 'fragment')
@@ -52,7 +52,7 @@ class TestDOM(unittest.TestCase):
         self.assertEqual(len(DOM.get_children(DOM.create_element('span', {}, DOM.create_element('span'), DOM.create_element('span')))), 2)
 
     def test_render(self):
-        self.assertEqual(DOM.render(DOM.create_element('a', {}, DOM.create_element('span', {'className': 'file-info icon-text'}, DOM.create_element('span', {'className': 'icon-text__text'}, 'Test test'), DOM.create_element('svg', {'className': 'icon'}, DOM.create_element('use', {'xlink:href': '#icon-test'}))))), '<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xmlns:ns0="http://www.w3.org/1999/xlink" ns0:href="#icon-test"></use></svg></span></a>')
+        self.assertEqual(DOM.render(DOM.create_element('a', {}, DOM.create_element('span', {'className': 'file-info icon-text'}, DOM.create_element('span', {'className': 'icon-text__text'}, 'Test test'), DOM.create_element('svg', {'className': 'icon'}, DOM.create_element('use', {'xlink:href': '#icon-test'}))))), '<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xlink:href="#icon-test"></use></svg></span></a>')
 
     def test_pretty_print(self):
-        self.assertEqual(DOM.pretty_print('<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xmlns:ns0="http://www.w3.org/1999/xlink" ns0:href="#icon-test"></use></svg></span></a>'), '\n  <a>\n    <span class="file-info icon-text">\n      <span class="icon-text__text">Test test</span>\n      <svg class="icon">\n        <use xmlns:ns0="http://www.w3.org/1999/xlink" ns0:href="#icon-test"/>\n      </svg>\n    </span>\n  </a>\n\n')
+        self.assertEqual(DOM.pretty_print('<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xlink:href="#icon-test"></use></svg></span></a>'), '<a>\n   <span class="file-info icon-text">\n    <span class="icon-text__text">\n     Test test\n    </span>\n    <svg class="icon">\n     <use xlink:href="#icon-test">\n     </use>\n    </svg>\n   </span>\n  </a>')

--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -6,6 +6,11 @@ from draftjs_exporter.dom import DOM
 
 
 class TestDOM(unittest.TestCase):
+    def test_create_tag(self):
+        self.assertEqual(DOM.get_tag_name(DOM.create_tag('p', {'class': 'intro'})), 'p')
+        self.assertEqual(DOM.get_class_list(DOM.create_tag('p', {'class': 'intro'})), ['intro'])
+        self.assertEqual(DOM.get_text_content(DOM.create_tag('p', {'class': 'intro'})), None)
+
     def test_create_element(self):
         self.assertEqual(DOM.get_tag_name(DOM.create_element('p', {'className': 'intro'}, 'Test test')), 'p')
         self.assertEqual(DOM.get_class_list(DOM.create_element('p', {'className': 'intro'}, 'Test test')), ['intro'])
@@ -39,6 +44,9 @@ class TestDOM(unittest.TestCase):
 
     def test_get_tag_name(self):
         self.assertEqual(DOM.get_tag_name(DOM.create_element('p', {}, 'Test test')), 'p')
+
+    def test_get_class_list(self):
+        self.assertEqual(DOM.get_class_list(DOM.create_element('p', {'className': 'intro test'}, 'Test test')), ['intro', 'test'])
 
     def test_get_text_content(self):
         self.assertEqual(DOM.get_text_content(DOM.create_element('p', {}, 'Test test')), 'Test test')

--- a/tests/test_exports.json
+++ b/tests/test_exports.json
@@ -276,7 +276,7 @@
 
     {
         "label": "From https://github.com/icelab/draft-js-ast-exporter/blob/651c807bea12d97dad6f4965ab40481c8f2130dd/test/fixtures/content.js",
-        "output": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><span><img src=\"http://placekitten.com/500/300\">)</span><p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>",
+        "output": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><span><img src=\"http://placekitten.com/500/300\"/>:)</span><p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>",
         "content_state": {
             "entityMap": {
                 "0": {

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -256,20 +256,20 @@ class TestOutput(unittest.TestCase):
                     'element': 'li',
                     'wrapper': ['ul', {'length': 5}],
                 },
-            })
+            }),
         }).render({
             'entityMap': {},
-                'blocks': [
-                    {
-                        'key': 'dem1p',
-                        'text': 'item1',
-                        'type': 'unordered-list-item',
-                        'depth': 0,
-                        'inlineStyleRanges': [],
-                        'entityRanges': []
-                    },
-                ]
-            }), '<ul length="5"><li>item1</li></ul>')
+            'blocks': [
+                {
+                    'key': 'dem1p',
+                    'text': 'item1',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': []
+                },
+            ],
+        }), '<ul length="5"><li>item1</li></ul>')
 
     def test_render_with_boolean_attribute_true(self):
         self.assertEqual(HTML({
@@ -278,20 +278,20 @@ class TestOutput(unittest.TestCase):
                     'element': 'li',
                     'wrapper': ['ul', {'disabled': True}],
                 },
-            })
+            }),
         }).render({
             'entityMap': {},
-                'blocks': [
-                    {
-                        'key': 'dem1p',
-                        'text': 'item1',
-                        'type': 'unordered-list-item',
-                        'depth': 0,
-                        'inlineStyleRanges': [],
-                        'entityRanges': []
-                    },
-                ]
-            }), '<ul disabled="True"><li>item1</li></ul>')
+            'blocks': [
+                {
+                    'key': 'dem1p',
+                    'text': 'item1',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': []
+                },
+            ],
+        }), '<ul disabled="True"><li>item1</li></ul>')
 
     def test_render_with_boolean_attribute_false(self):
         self.assertEqual(HTML({
@@ -300,20 +300,20 @@ class TestOutput(unittest.TestCase):
                     'element': 'li',
                     'wrapper': ['ul', {'disabled': False}],
                 },
-            })
+            }),
         }).render({
             'entityMap': {},
-                'blocks': [
-                    {
-                        'key': 'dem1p',
-                        'text': 'item1',
-                        'type': 'unordered-list-item',
-                        'depth': 0,
-                        'inlineStyleRanges': [],
-                        'entityRanges': []
-                    },
-                ]
-            }), '<ul disabled="False"><li>item1</li></ul>')
+            'blocks': [
+                {
+                    'key': 'dem1p',
+                    'text': 'item1',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': []
+                },
+            ]
+        }), '<ul disabled="False"><li>item1</li></ul>')
 
     def test_render_with_none_attribute(self):
         self.assertEqual(HTML({
@@ -322,20 +322,20 @@ class TestOutput(unittest.TestCase):
                     'element': 'li',
                     'wrapper': ['ul', {'disabled': None}],
                 },
-            })
+            }),
         }).render({
             'entityMap': {},
-                'blocks': [
-                    {
-                        'key': 'dem1p',
-                        'text': 'item1',
-                        'type': 'unordered-list-item',
-                        'depth': 0,
-                        'inlineStyleRanges': [],
-                        'entityRanges': []
-                    },
-                ]
-            }), '<ul><li>item1</li></ul>')
+            'blocks': [
+                {
+                    'key': 'dem1p',
+                    'text': 'item1',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': []
+                },
+            ],
+        }), '<ul><li>item1</li></ul>')
 
     def test_render_with_unknown_attribute(self):
         self.assertEqual(HTML({
@@ -347,17 +347,17 @@ class TestOutput(unittest.TestCase):
             })
         }).render({
             'entityMap': {},
-                'blocks': [
-                    {
-                        'key': 'dem1p',
-                        'text': 'item1',
-                        'type': 'unordered-list-item',
-                        'depth': 0,
-                        'inlineStyleRanges': [],
-                        'entityRanges': []
-                    },
-                ]
-            }), '<ul *ngfor="test"><li>item1</li></ul>')
+            'blocks': [
+                {
+                    'key': 'dem1p',
+                    'text': 'item1',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': []
+                },
+            ],
+        }), '<ul *ngfor="test"><li>item1</li></ul>')
 
     def test_render_with_token_entity(self):
         self.assertEqual(self.exporter.render({

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -83,7 +83,7 @@ class TestOutput(unittest.TestCase):
                     'entityRanges': []
                 }
             ]
-        }), '<p>Emojis! &#127866;</p>')
+        }), '<p>Emojis! \U0001f37a</p>')
 
     def test_render_with_inline_styles(self):
         self.assertEqual(self.exporter.render({
@@ -290,7 +290,7 @@ class TestOutput(unittest.TestCase):
                     ],
                 },
             ]
-        }), '<ul class="steps"><li>item1</li><li>item2</li></ul><hr>')
+        }), '<ul class="steps"><li>item1</li><li>item2</li></ul><hr/>')
 
     def test_render_with_unidirectional_nested_wrapping(self):
         self.assertEqual(self.exporter.render({

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -249,6 +249,116 @@ class TestOutput(unittest.TestCase):
             ]
         }), '<ul class="steps"><li>item1</li><li>item2</li></ul>')
 
+    def test_render_with_number_attribute(self):
+        self.assertEqual(HTML({
+            'block_map': dict(BLOCK_MAP, **{
+                BLOCK_TYPES.UNORDERED_LIST_ITEM: {
+                    'element': 'li',
+                    'wrapper': ['ul', {'length': 5}],
+                },
+            })
+        }).render({
+            'entityMap': {},
+                'blocks': [
+                    {
+                        'key': 'dem1p',
+                        'text': 'item1',
+                        'type': 'unordered-list-item',
+                        'depth': 0,
+                        'inlineStyleRanges': [],
+                        'entityRanges': []
+                    },
+                ]
+            }), '<ul length="5"><li>item1</li></ul>')
+
+    def test_render_with_boolean_attribute_true(self):
+        self.assertEqual(HTML({
+            'block_map': dict(BLOCK_MAP, **{
+                BLOCK_TYPES.UNORDERED_LIST_ITEM: {
+                    'element': 'li',
+                    'wrapper': ['ul', {'disabled': True}],
+                },
+            })
+        }).render({
+            'entityMap': {},
+                'blocks': [
+                    {
+                        'key': 'dem1p',
+                        'text': 'item1',
+                        'type': 'unordered-list-item',
+                        'depth': 0,
+                        'inlineStyleRanges': [],
+                        'entityRanges': []
+                    },
+                ]
+            }), '<ul disabled="True"><li>item1</li></ul>')
+
+    def test_render_with_boolean_attribute_false(self):
+        self.assertEqual(HTML({
+            'block_map': dict(BLOCK_MAP, **{
+                BLOCK_TYPES.UNORDERED_LIST_ITEM: {
+                    'element': 'li',
+                    'wrapper': ['ul', {'disabled': False}],
+                },
+            })
+        }).render({
+            'entityMap': {},
+                'blocks': [
+                    {
+                        'key': 'dem1p',
+                        'text': 'item1',
+                        'type': 'unordered-list-item',
+                        'depth': 0,
+                        'inlineStyleRanges': [],
+                        'entityRanges': []
+                    },
+                ]
+            }), '<ul disabled="False"><li>item1</li></ul>')
+
+    def test_render_with_none_attribute(self):
+        self.assertEqual(HTML({
+            'block_map': dict(BLOCK_MAP, **{
+                BLOCK_TYPES.UNORDERED_LIST_ITEM: {
+                    'element': 'li',
+                    'wrapper': ['ul', {'disabled': None}],
+                },
+            })
+        }).render({
+            'entityMap': {},
+                'blocks': [
+                    {
+                        'key': 'dem1p',
+                        'text': 'item1',
+                        'type': 'unordered-list-item',
+                        'depth': 0,
+                        'inlineStyleRanges': [],
+                        'entityRanges': []
+                    },
+                ]
+            }), '<ul><li>item1</li></ul>')
+
+    def test_render_with_unknown_attribute(self):
+        self.assertEqual(HTML({
+            'block_map': dict(BLOCK_MAP, **{
+                BLOCK_TYPES.UNORDERED_LIST_ITEM: {
+                    'element': 'li',
+                    'wrapper': ['ul', {'*ngFor': 'test'}],
+                },
+            })
+        }).render({
+            'entityMap': {},
+                'blocks': [
+                    {
+                        'key': 'dem1p',
+                        'text': 'item1',
+                        'type': 'unordered-list-item',
+                        'depth': 0,
+                        'inlineStyleRanges': [],
+                        'entityRanges': []
+                    },
+                ]
+            }), '<ul *ngfor="test"><li>item1</li></ul>')
+
     def test_render_with_token_entity(self):
         self.assertEqual(self.exporter.render({
             'entityMap': {


### PR DESCRIPTION
For the following reasons:

- BeautifulSoup4 and html5lib are already dependencies of wagtail, thus lowering the overall number of dependencies on the project
- lxml requires libxml2 and local compilation, whereas html5lib is 100% python
- lxml's documentation quality is quite poor
- To the extent of my knowledge, lxml doesn't support custom attributes (as BeautifulSoup's docs put it, html5lib's extreme leniency is an advantage)

Drawbacks:

- It is much slower.
- It's 2 dependencies instead of 1. Perhaps we could only use `html5lib`, but its has nearly no documentation.