### PR TITLE
Add support for arbitrary nesting jumps. Fix #18

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,6 @@ draftjs_exporter documentation
 
 ### Unsupported markup
 
-* Nested blocks where nesting jumps one level of depth (depth = 0, then depth = 2).
 
 ## R&D notes
 

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -49,10 +49,10 @@ class WrapperState:
         return '<WrapperState: %s>' % self.to_string()
 
     def set_wrapper(self, options=None, depth=0):
-        if not options:
-            element = DOM.create_document_fragment()
-        else:
+        if options:
             element = DOM.create_element(options[0], options[1])
+        else:
+            element = DOM.create_document_fragment()
 
         new_wrapper = [element, depth, options]
 

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -33,7 +33,7 @@ class WrapperState:
         elt_options = self.map_element_options(block_options.get('element'))
         elt = DOM.create_element(elt_options[0], elt_options[1])
 
-        parent = self.parent_for(type_, depth)
+        parent = self.parent_for(block_options, depth)
         DOM.append_child(parent, elt)
 
         # At level 0, the element is added to the document.
@@ -73,8 +73,7 @@ class WrapperState:
     def get_wrapper_options(self, depth=-1):
         return self.wrapper_stack[depth][2]
 
-    def parent_for(self, type_, depth):
-        block_options = self.get_block_options(type_)
+    def parent_for(self, block_options, depth):
         wrapper_options = block_options.get('wrapper', None)
 
         if wrapper_options:

--- a/example.py
+++ b/example.py
@@ -21,7 +21,7 @@ config = {
     'block_map': dict(BLOCK_MAP, **{
         BLOCK_TYPES.HEADER_TWO: {
             'element': ['h2', {'className': 'c-amazing-heading'}],
-            'wrapper': 'hgroup',
+            'wrapper': 'div',
         },
         BLOCK_TYPES.UNORDERED_LIST_ITEM: {
             'element': 'li',

--- a/example.py
+++ b/example.py
@@ -275,4 +275,4 @@ print(pretty)
 
 # Output to a file
 with codecs.open('example.html', 'w', 'utf-8') as file:
-    file.write('<meta charset="utf-8" />\n' + pretty)
+    file.write('<!DOCTYPE html><html><head><meta charset="utf-8" /><title>Test</title></head><body>\n{pretty}\n</body></html>'.format(pretty=pretty))

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from draftjs_exporter.constants import Enum, BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Enum
 
 
 class EnumConstants(unittest.TestCase):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -596,6 +596,53 @@ class TestOutput(unittest.TestCase):
             ],
         }), '<ul class="steps"><li>A list item (0)<ul class="steps"><li>Oops! (1)<ul class="steps"><li>Does this support nesting? (2)</li><li>Maybe? (2)<ul class="steps"><li>Yep it does! (3)<ul class="steps"><li>How many levels deep? (4)</li></ul></li></ul></li><li>Backtracking, two at once... (2)</li></ul></li><li>Uh oh (1)<ul class="steps"><li>Up, up, and away! (2)</li></ul></li><li>Arh! (1)</li></ul></li><li>Did this work? (0)</li><li>Yes! (0)</li></ul>')
 
+    def test_render_with_jumping_wrapping(self):
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'key': '93agv',
+                    'text': 'A list item (0)',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '4ht9m',
+                    'text': 'Jumps (2)',
+                    'type': 'unordered-list-item',
+                    'depth': 2,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': 'c6gc4',
+                    'text': 'Back (0)',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': 'c6gc3',
+                    'text': 'Jumps again (3)',
+                    'type': 'unordered-list-item',
+                    'depth': 3,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '3mn5b',
+                    'text': 'Back (1)',
+                    'type': 'unordered-list-item',
+                    'depth': 1,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+            ],
+        }), '<ul class="steps"><li>A list item (0)<ul class="steps"><li><ul class="steps"><li>Jumps (2)</li></ul></li></ul></li><li>Back (0)<ul class="steps"><li><ul class="steps"><li><ul class="steps"><li>Jumps again (3)</li></ul></li></ul></li><li>Back (1)</li></ul></li></ul>')
+
     def test_render_with_big_content(self):
         self.assertEqual(HTML({
             'entity_decorators': {


### PR DESCRIPTION
Fix for #18.

Allows the following markup:

<ul class="bullet-list">
    <li>A list item (0)
        <ul class="bullet-list">
            <li>
                <ul class="bullet-list">
                    <li>A list item (2)</li>
                </ul>
            </li>
        </ul>
    </li>
</ul>

```
<ul class="bullet-list">
    <li>A list item (0)
        <ul class="bullet-list">
            <li>
                <ul class="bullet-list">
                    <li>A list item (2)</li>
                </ul>
            </li>
        </ul>
    </li>
</ul>
```