### PR TITLE
Add support for rare cases where blocks start with a non-zero depth

### DIFF
--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -29,6 +29,8 @@ class HTML:
         for block in content_state.get('blocks', []):
             self.render_block(block, entity_map)
 
+        self.wrapper_state.clean_up()
+
         return self.wrapper_state.to_string()
 
     def render_block(self, block, entity_map):

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -19,10 +19,7 @@ class WrapperState:
         self.block_map = block_map
         self.document = DOM.create_document_fragment()
 
-        self.wrapper_stack = [
-            # Default wrapper element is a fragment, does not have options.
-            [DOM.create_document_fragment(), 0, []],
-        ]
+        self.wrapper_stack = []
 
     def element_for(self, block):
         type_ = block.get('type', 'unstyled')
@@ -48,7 +45,7 @@ class WrapperState:
     def __str__(self):
         return '<WrapperState: %s>' % self.to_string()
 
-    def set_wrapper(self, options=None, elt_options=None, depth=0):
+    def set_wrapper(self, options=None, elt_options=None, depth=-1):
         if depth >= len(self.wrapper_stack):
             for d in range(len(self.wrapper_stack), depth + 1):
                 wrapper_elt = self.create_wrapper_elt(options)
@@ -84,10 +81,10 @@ class WrapperState:
         return wrapper_elt
 
     def get_wrapper_elt(self, depth=-1):
-        return self.wrapper_stack[depth][0]
+        return self.wrapper_stack[depth][0] if len(self.wrapper_stack) > 0 else DOM.create_document_fragment()
 
     def get_wrapper_depth(self, depth=-1):
-        return self.wrapper_stack[depth][1]
+        return self.wrapper_stack[depth][1] if len(self.wrapper_stack) > 0 else -1
 
     def get_wrapper_options(self, depth=-1):
         return self.wrapper_stack[depth][2]

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -73,12 +73,7 @@ class WrapperStack:
         return wrapper
 
     def tail(self):
-        if self.length() > 0:
-            wrapper = self.get(0)
-        else:
-            wrapper = Wrapper(-1, None)
-
-        return wrapper
+        return self.get(0)
 
 
 class Wrapper:

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -12,11 +12,14 @@ class Options:
     """
     Facilitates querying configuration from the block_map.
     """
+    def __init__(self, element_options, wrapper_options):
+        self.element = Options.map(element_options)
+        self.wrapper = Options.map(wrapper_options) if wrapper_options else None
 
     @staticmethod
     def map(opts):
         """
-        Used for elements and wrappers. Supports the following options formats:
+        Supports the following options formats:
         'ul'
         ['ul']
         ['ul', {'className': 'bullet-list'}]
@@ -31,18 +34,59 @@ class Options:
         return [tag, attributes]
 
     @staticmethod
-    def block(block_map, type_):
+    def for_block(block_map, type_):
         block_options = block_map.get(type_)
 
         if block_options is None:
             raise BlockException('Block "%s" does not exist in block_map' % type_)
 
-        return block_options
+        return Options(block_options.get('element'), block_options.get('wrapper'))
 
 
 class WrapperStack:
+    """
+    Stack data structure for element wrappers.
+    The bottom of the stack contains the elements closest to the page body.
+    The top of the stack contains the most nested nodes.
+    """
     def __init__(self):
         self.stack = []
+
+    def length(self):
+        return len(self.stack)
+
+    def append(self, wrapper):
+        return self.stack.append(wrapper)
+
+    def get(self, index):
+        return self.stack[index]
+
+    def slice(self, length):
+        self.stack = self.stack[:length]
+
+    def top(self):
+        if self.length() > 0:
+            wrapper = self.get(-1)
+        else:
+            wrapper = Wrapper(-1, None)
+
+        return wrapper
+
+
+class Wrapper:
+    """
+    A wrapper is an element that wraps other nodes. It gets created
+    when the depth of a block is different than 0, so the DOM elements
+    have the appropriate amount of nesting.
+    """
+    def __init__(self, depth, options):
+        if options:
+            self.elt = DOM.create_element(options[0], options[1])
+        else:
+            self.elt = DOM.create_document_fragment()
+
+        self.depth = depth
+        self.options = options
 
 
 class WrapperState:
@@ -56,20 +100,23 @@ class WrapperState:
         self.block_map = block_map
         self.document = DOM.create_document_fragment()
 
-        # Stack of nested wrapper elements. Each item has the following shape:
-        # [elt (DOM node), depth level (int), options (list)]
-        self.stack = []
+        self.stack = WrapperStack()
+
+    def __str__(self):
+        return '<WrapperState: %s>' % self.to_string()
+
+    def to_string(self):
+        return DOM.render(self.document)
 
     def element_for(self, block):
         type_ = block.get('type', 'unstyled')
         depth = block.get('depth', 0)
-        block_options = Options.block(self.block_map, type_)
+        options = Options.for_block(self.block_map, type_)
 
         # Make an element from the options specified in the block map.
-        elt_options = Options.map(block_options.get('element'))
-        elt = DOM.create_element(elt_options[0], elt_options[1])
+        elt = DOM.create_element(options.element[0], options.element[1])
 
-        parent = self.parent_for(block_options, depth)
+        parent = self.parent_for(options, depth)
         DOM.append_child(parent, elt)
 
         # At level 0, the element is added to the document.
@@ -78,81 +125,51 @@ class WrapperState:
 
         return elt
 
-    def to_string(self):
-        return DOM.render(self.document)
-
-    def __str__(self):
-        return '<WrapperState: %s>' % self.to_string()
-
-    def set_wrapper(self, options=None, elt_options=None, depth=-1):
-        if depth >= self.stack_length():
-            for d in range(self.stack_length(), depth + 1):
-                new_wrapper = self.create_wrapper(d, options)
-
-                wrapper_children = DOM.get_children(self.get_top_wrapper().get('elt'))
-
-                # Determine where to append the new wrapper.
-                if len(wrapper_children) > 0:
-                    wrapper_parent = wrapper_children[-1]
-                else:
-                    # If there is no content in the current wrapper, we need
-                    # to add an intermediary node.
-                    wrapper_parent = DOM.create_element(elt_options[0], elt_options[1])
-                    DOM.append_child(self.get_top_wrapper().get('elt'), wrapper_parent)
-
-                DOM.append_child(wrapper_parent, new_wrapper.get('elt'))
-
-                self.stack.append(new_wrapper)
+    def parent_for(self, options, depth):
+        if options.wrapper:
+            parent = self.get_wrapper_elt(options, depth)
         else:
-            new_wrapper = self.create_wrapper(depth, options)
-
-            # Cut the stack to where it now stops, and add new wrapper.
-            self.stack = self.stack[:depth] + [new_wrapper]
-
-    def create_wrapper(self, depth, options):
-        if options:
-            elt = DOM.create_element(options[0], options[1])
-        else:
-            elt = DOM.create_document_fragment()
-
-        return {
-            'elt': elt,
-            'depth': depth,
-            'options': options,
-        }
-
-    def get_top_wrapper(self):
-        if self.stack_length() > 0:
-            wrapper = self.stack[-1]
-        else:
-            wrapper = self.create_wrapper(-1, None)
-
-        return wrapper
-
-    def parent_for(self, block_options, depth):
-        elt_options = Options.map(block_options.get('element'))
-        wrapper_options = block_options.get('wrapper', None)
-
-        if wrapper_options:
-            parent = self.get_wrapper(Options.map(wrapper_options), elt_options, depth)
-        else:
-            parent = self.reset_stack()
+            # Reset the stack if there is no wrapper.
+            self.stack.slice(-1)
+            self.stack.append(Wrapper(-1, None))
+            parent = self.stack.top().elt
 
         return parent
 
-    def get_wrapper(self, wrapper_options, elt_options, depth):
-        if depth > self.get_top_wrapper().get('depth') or wrapper_options != self.get_top_wrapper().get('options'):
-            self.set_wrapper(wrapper_options, elt_options, depth)
+    def get_wrapper_elt(self, options, depth):
+        if depth > self.stack.top().depth or options.wrapper != self.stack.top().options:
+            self.update_stack(options, depth)
 
-        # If depth is lower than the maximum, we need to cut the stack.
-        if depth < self.get_top_wrapper().get('depth'):
-            self.stack = self.stack[:depth + 1]
+        # If depth is lower than the maximum, we cut the stack.
+        if depth < self.stack.top().depth:
+            self.stack.slice(depth + 1)
 
-        return self.stack[depth].get('elt')
+        return self.stack.get(depth).elt
 
-    def stack_length(self):
-        return len(self.stack)
+    def update_stack(self, options, depth):
+        if depth >= self.stack.length():
+            # If the depth is gte the stack length, we need more wrappers.
+            depth_levels = range(self.stack.length(), depth + 1);
 
-    def reset_stack(self):
-        self.set_wrapper()
-        return self.get_top_wrapper().get('elt')
+            for level in depth_levels:
+                new_wrapper = Wrapper(level, options.wrapper)
+
+                wrapper_children = DOM.get_children(self.stack.top().elt)
+
+                # Determine where to append the new wrapper.
+                if len(wrapper_children) == 0:
+                    # If there is no content in the current wrapper, we need
+                    # to add an intermediary node.
+                    wrapper_parent = DOM.create_element(options.element[0], options.element[1])
+                    DOM.append_child(self.stack.top().elt, wrapper_parent)
+                else:
+                    # Otherwise we can append at the end of the last child.
+                    wrapper_parent = wrapper_children[-1]
+
+                DOM.append_child(wrapper_parent, new_wrapper.elt)
+
+                self.stack.append(new_wrapper)
+        else:
+            # Cut the stack to where it now stops, and add new wrapper.
+            self.stack.slice(depth)
+            self.stack.append(Wrapper(depth, options.wrapper))

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -643,6 +643,29 @@ class TestOutput(unittest.TestCase):
             ],
         }), '<ul class="steps"><li>A list item (0)<ul class="steps"><li><ul class="steps"><li>Jumps (2)</li></ul></li></ul></li><li>Back (0)<ul class="steps"><li><ul class="steps"><li><ul class="steps"><li>Jumps again (3)</li></ul></li></ul></li><li>Back (1)</li></ul></li></ul>')
 
+    def test_render_with_immediate_jumping(self):
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'key': '93agv',
+                    'text': 'A list item (2)',
+                    'type': 'unordered-list-item',
+                    'depth': 2,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '93agv',
+                    'text': 'A list item (0)',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+            ],
+        }), '<ul class="steps"><li><ul class="steps"><li><ul class="steps"><li>A list item (2)</li></ul></li></ul></li><li>A list item (0)</li></ul>')
+
     def test_render_with_big_content(self):
         self.assertEqual(HTML({
             'entity_decorators': {

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -666,6 +666,29 @@ class TestOutput(unittest.TestCase):
             ],
         }), '<ul class="steps"><li><ul class="steps"><li><ul class="steps"><li>A list item (2)</li></ul></li></ul></li><li>A list item (0)</li></ul>')
 
+    def test_render_with_no_zero_depth(self):
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'key': '93agv',
+                    'text': 'A list item (2)',
+                    'type': 'unordered-list-item',
+                    'depth': 2,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '93agv',
+                    'text': 'A list item (2)',
+                    'type': 'unordered-list-item',
+                    'depth': 2,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+            ],
+        }), '<ul class="steps"><li><ul class="steps"><li><ul class="steps"><li>A list item (2)</li><li>A list item (2)</li></ul></li></ul></li></ul>')
+
     def test_render_with_big_content(self):
         self.assertEqual(HTML({
             'entity_decorators': {

--- a/tests/test_wrapper_state.py
+++ b/tests/test_wrapper_state.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.wrapper_state import BlockException, WrapperState
+from draftjs_exporter.wrapper_state import BlockException, Options, WrapperState
 
 
 class TestWrapperState(unittest.TestCase):
@@ -78,7 +78,7 @@ class TestWrapperState(unittest.TestCase):
         self.assertEqual(str(self.wrapper_state), '<WrapperState: <h1></h1>>')
 
     def test_map_element_options_full(self):
-        self.assertEqual(self.wrapper_state.map_element_options([
+        self.assertEqual(Options.map([
             'ul',
             {'className': 'bullet-list'},
         ]), [
@@ -87,7 +87,7 @@ class TestWrapperState(unittest.TestCase):
         ])
 
     def test_map_element_options_half(self):
-        self.assertEqual(self.wrapper_state.map_element_options([
+        self.assertEqual(Options.map([
             'ul',
         ]), [
             'ul',
@@ -95,7 +95,7 @@ class TestWrapperState(unittest.TestCase):
         ])
 
     def test_map_element_options_simplest(self):
-        self.assertEqual(self.wrapper_state.map_element_options('ul'), [
+        self.assertEqual(Options.map('ul'), [
             'ul',
             {},
         ])


### PR DESCRIPTION
Tackles very specific markup where blocks have a non-zero depth, like:

<ul class="bullet-list">
   <li>
    <ul class="bullet-list">
     <li>
      <ul class="bullet-list">
       <li>
        A list item (2)
       </li>
       <li>
        A list item (2)
       </li>
      </ul>
     </li>
    </ul>
   </li>
  </ul>

or 

<ul class="bullet-list">
   <li>
    <ul class="bullet-list">
     <li>
      <ul class="bullet-list">
       <li>
        A list item (2)
       </li>
      </ul>
     </li>
     <li>
      A list item (1)
     </li>
    </ul>
   </li>
  </ul>

or

<ul class="bullet-list">
   <li>
    <ul class="bullet-list">
     <li>
      <ul class="bullet-list">
       <li>
        A list item (2)
       </li>
      </ul>
     </li>
    </ul>
   </li>
       <li>
        A list item (0)
       </li>
  </ul>