### PR TITLE
Add support for children control in entity decorator API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ Changelog
 > All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [[v0.x.y]](https://github.com/springload/draftjs_exporter/releases/tag/v0.x.y) - 2016-10-15
+## [[v0.5.0]](https://github.com/springload/draftjs_exporter/releases/tag/v0.x.y) - 2016-11-17
+
+This release is likely to be a **breaking change**. It is not released as such because the exporter has not [reached 1.0 yet](http://semver.org/#spec-item-4).
 
 ### Added
 
 - Add support for more scenarios with nested blocks. Jumping depths eg. 0, 2, 3. Starting directly above 0 eg. 2, 2, 0. Not using 0 at all eg. 3, 3, 3.
+
+### Changed
+
+- Entity decorators now have complete control on where their content (markup, not just text) is inserted into the DOM. This is done via the `children` prop in a similar fashion to React's.
 
 ### Removed
 

--- a/draftjs_exporter/entities.py
+++ b/draftjs_exporter/entities.py
@@ -34,7 +34,7 @@ class Link:
             attr = key if key != 'url' else 'href'
             attributes[attr] = data[key]
 
-        return DOM.create_element('a', attributes)
+        return DOM.create_element('a', attributes, props['children'])
 
 
 class Button:

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -35,14 +35,15 @@ class HTML:
 
     def render_block(self, block, entity_map):
         element = self.wrapper_state.element_for(block)
-        entity_state = EntityState(element, self.entity_decorators, entity_map)
+        entity_state = EntityState(self.entity_decorators, entity_map)
 
         for (text, commands) in self.build_command_groups(block):
             for command in commands:
                 entity_state.apply(command)
                 self.style_state.apply(command)
 
-            self.style_state.add_node(entity_state.current_parent(), text)
+            style_node = self.style_state.create_node(text)
+            entity_state.render_entitities(element, style_node)
 
     def build_command_groups(self, block):
         """

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -35,7 +35,6 @@ class StyleState:
     def is_unstyled(self):
         return not self.styles
 
-    # TODO To unit test.
     def get_style_tags(self):
         tags = []
 

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -56,20 +56,21 @@ class StyleState:
 
         return ''.join(sorted(rules))
 
-    def add_node(self, element, text):
+    def create_node(self, text):
         if self.is_unstyled():
-            child = DOM.create_text_node(text)
-            DOM.append_child(element, child)
+            node = DOM.create_text_node(text)
         else:
             tags = self.get_style_tags()
-            child = element
+            node = DOM.create_element(tags[0])
+            child = node
 
             # Nest the tags.
             # Set the text and style attribute (if any) on the deepest node.
-            for tag in tags:
-                new_child = DOM.create_element(tag)
-                DOM.append_child(child, new_child)
-                child = new_child
+            for i, tag in enumerate(tags):
+                if i > 0:
+                    new_child = DOM.create_element(tag)
+                    DOM.append_child(child, new_child)
+                    child = new_child
 
             style_value = self.get_style_value()
             if style_value:
@@ -77,4 +78,4 @@ class StyleState:
 
             DOM.set_text_content(child, text)
 
-        return child
+        return node

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -66,11 +66,10 @@ class StyleState:
 
             # Nest the tags.
             # Set the text and style attribute (if any) on the deepest node.
-            for i, tag in enumerate(tags):
-                if i > 0:
-                    new_child = DOM.create_element(tag)
-                    DOM.append_child(child, new_child)
-                    child = new_child
+            for tag in tags[1:]:
+                new_child = DOM.create_element(tag)
+                DOM.append_child(child, new_child)
+                child = new_child
 
             style_value = self.get_style_value()
             if style_value:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -54,10 +54,11 @@ class TestLink(unittest.TestCase):
         link = DOM.create_element(Link, {
             'data': {
                 'url': 'http://example.com',
-            }
+            },
+            'children': 'wow',
         })
         self.assertEqual(DOM.get_tag_name(link), 'a')
-        self.assertEqual(DOM.get_text_content(link), None)
+        self.assertEqual(DOM.get_text_content(link), 'wow')
         self.assertEqual(link.get('href'), 'http://example.com')
 
 

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 
 from draftjs_exporter.command import Command
-from draftjs_exporter.dom import DOM
 from draftjs_exporter.entities import Link
 from draftjs_exporter.entity_state import EntityException, EntityState
 
@@ -24,17 +23,15 @@ entity_map = {
 
 class TestEntityState(unittest.TestCase):
     def setUp(self):
-        self.entity_state = EntityState(DOM.create_element('div'), entity_decorators, entity_map)
+        self.entity_state = EntityState(entity_decorators, entity_map)
 
     def test_init(self):
         self.assertIsInstance(self.entity_state, EntityState)
 
     def test_apply_start_entity(self):
-        self.assertEqual(DOM.get_tag_name(self.entity_state.entity_stack[-1][0]), 'fragment')
-        self.assertEqual(self.entity_state.entity_stack[-1][1], {})
+        self.assertEqual(len(self.entity_state.entity_stack), 0)
         self.entity_state.apply(Command('start_entity', 0, 0))
-        self.assertEqual(DOM.get_tag_name(self.entity_state.entity_stack[-1][0]), 'a')
-        self.assertEqual(self.entity_state.entity_stack[-1][1], {
+        self.assertEqual(self.entity_state.entity_stack[-1], {
             'data': {
                 'url': 'http://example.com'
             },
@@ -43,12 +40,10 @@ class TestEntityState(unittest.TestCase):
         })
 
     def test_apply_stop_entity(self):
-        self.assertEqual(DOM.get_tag_name(self.entity_state.entity_stack[-1][0]), 'fragment')
-        self.assertEqual(self.entity_state.entity_stack[-1][1], {})
+        self.assertEqual(len(self.entity_state.entity_stack), 0)
         self.entity_state.apply(Command('start_entity', 0, 0))
         self.entity_state.apply(Command('stop_entity', 5, 0))
-        self.assertEqual(DOM.get_tag_name(self.entity_state.entity_stack[-1][0]), 'fragment')
-        self.assertEqual(self.entity_state.entity_stack[-1][1], {})
+        self.assertEqual(len(self.entity_state.entity_stack), 0)
 
     def test_get_entity_details(self):
         self.assertEqual(self.entity_state.get_entity_details(Command('start_entity', 0, 0)), {

--- a/tests/test_exports.json
+++ b/tests/test_exports.json
@@ -351,7 +351,7 @@
                 },
                 {
                     "key": "9vgd",
-                    "text": ":)",
+                    "text": " :)",
                     "type": "atomic",
                     "depth": 0,
                     "inlineStyleRanges": [],

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -49,16 +49,16 @@ class TestStyleState(unittest.TestCase):
         self.style_state.apply(Command('start_inline_style', 0, 'HIGHLIGHT'))
         self.assertEqual(self.style_state.get_style_value(), 'text-decoration: underline;')
 
-    def test_add_node_unstyled(self):
-        self.assertEqual(DOM.get_tag_name(self.style_state.add_node(DOM.create_element('p'), 'Test text')), 'textnode')
-        self.assertEqual(DOM.get_text_content(self.style_state.add_node(DOM.create_element('p'), 'Test text')), 'Test text')
+    def test_create_node_unstyled(self):
+        self.assertEqual(DOM.get_tag_name(self.style_state.create_node('Test text')), 'textnode')
+        self.assertEqual(DOM.get_text_content(self.style_state.create_node('Test text')), 'Test text')
 
-    def test_add_node_unicode(self):
-        self.assertEqual(DOM.get_text_content(self.style_state.add_node(DOM.create_element('p'), '🍺')), '🍺')
+    def test_create_node_unicode(self):
+        self.assertEqual(DOM.get_text_content(self.style_state.create_node('🍺')), '🍺')
 
-    def test_add_node_styled(self):
+    def test_create_node_styled(self):
         self.style_state.apply(Command('start_inline_style', 0, 'ITALIC'))
-        self.assertEqual(DOM.get_tag_name(self.style_state.add_node(DOM.create_element('p'), 'Test text')), 'em')
-        self.assertEqual(self.style_state.add_node(DOM.create_element('p'), 'Test text').get('style'), None)
-        self.assertEqual(DOM.get_text_content(self.style_state.add_node(DOM.create_element('p'), 'Test text')), 'Test text')
+        self.assertEqual(DOM.get_tag_name(self.style_state.create_node('Test text')), 'em')
+        self.assertEqual(self.style_state.create_node('Test text').get('style'), None)
+        self.assertEqual(DOM.get_text_content(self.style_state.create_node('Test text')), 'Test text')
         self.style_state.apply(Command('stop_inline_style', 9, 'ITALIC'))

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -62,3 +62,10 @@ class TestStyleState(unittest.TestCase):
         self.assertEqual(self.style_state.create_node('Test text').get('style'), None)
         self.assertEqual(DOM.get_text_content(self.style_state.create_node('Test text')), 'Test text')
         self.style_state.apply(Command('stop_inline_style', 9, 'ITALIC'))
+
+    def test_create_node_styled_multiple(self):
+        self.style_state.apply(Command('start_inline_style', 0, 'BOLD'))
+        self.style_state.apply(Command('start_inline_style', 0, 'ITALIC'))
+        self.assertEqual(self.style_state.get_style_tags(), ['em', 'strong'])
+        self.assertEqual(DOM.get_tag_name(self.style_state.create_node('wow')), 'em')
+        self.assertEqual(DOM.get_tag_name(DOM.get_children(self.style_state.create_node('wow'))[0]), 'strong')


### PR DESCRIPTION
Addresses #19.

The previous way of inserting those nodes was a bit backwards. Now control is left to the user, similar to what React components do with the `children` prop.

```python
class Link:
    def render(self, props):
        data = props.get('data', {})
        attributes = {}
        for key in data:
            attr = key if key != 'url' else 'href'
            attributes[attr] = data[key]

        return DOM.create_element('a', attributes, props['children'])
```