### PR TITLE
Add basic support for block-level data

### DIFF
--- a/draftjs_exporter/defaults.py
+++ b/draftjs_exporter/defaults.py
@@ -17,7 +17,7 @@ BLOCK_MAP = {
     # TODO Ideally would want double wrapping in pre + code.
     # See https://github.com/sstur/draft-js-export-html/blob/master/src/stateToHTML.js#L88
     BLOCK_TYPES.CODE: 'pre',
-    BLOCK_TYPES.ATOMIC: None,
+    BLOCK_TYPES.ATOMIC: lambda props: props['children'],
 }
 
 # Default style map to extend.

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -50,12 +50,12 @@ class DOM(object):
         )
         https://facebook.github.io/react/docs/top-level-api.html#react.createelement
         """
-        if props is None:
-            props = {}
-
         if not type_:
             elt = DOM.create_document_fragment()
         else:
+            if props is None:
+                props = {}
+
             attributes = {}
 
             # Map props from React/Draft.js to HTML lingo.

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -86,8 +86,13 @@ class DOM(object):
                 attributes['children'] = children[0] if len(children) == 1 else children
                 elt = type_(attributes)
             else:
+
                 # Never render children attribute on a raw tag.
                 attributes.pop('children', None)
+
+                # Never render block attribute on a raw tag.
+                attributes.pop('block', None)
+
                 elt = DOM.create_tag(type_, attributes)
 
                 for child in children:

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -55,15 +55,14 @@ class EntityState:
 
         self.entity_stack.pop()
 
-    def render_entitities(self, root_element, style_node):
+    def render_entitities(self, style_node):
         if self.is_empty():
-            DOM.append_child(root_element, style_node)
+            elt = style_node
         else:
-            stack_start = DOM.create_document_fragment()
-            DOM.append_child(root_element, stack_start)
+            elt = DOM.create_document_fragment()
 
-            element_stack = [stack_start]
-            new_element = stack_start
+            element_stack = [elt]
+            new_element = elt
 
             for entity_details in self.entity_stack:
                 decorator = self.get_entity_decorator(entity_details)
@@ -72,3 +71,5 @@ class EntityState:
                 new_element = DOM.create_element(decorator, props, style_node)
                 DOM.append_child(element_stack[-1], new_element)
                 element_stack.append(new_element)
+
+        return elt

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -41,7 +41,7 @@ class HTML:
         return self.wrapper_state.to_string()
 
     def render_block(self, block, entity_map):
-        element = self.wrapper_state.element_for(block)
+        content = DOM.create_document_fragment()
         entity_state = EntityState(self.entity_decorators, entity_map)
         style_state = StyleState(self.style_map)
 
@@ -57,7 +57,9 @@ class HTML:
                 decorated_node = DOM.create_text_node(text)
 
             styled_node = style_state.render_styles(decorated_node)
-            entity_state.render_entitities(element, styled_node)
+            DOM.append_child(content, entity_state.render_entitities(styled_node))
+
+        self.wrapper_state.element_for(block, content)
 
     def build_command_groups(self, block):
         """

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -13,7 +13,7 @@ class Options:
     """
     def __init__(self, element, props=None, wrapper=None, wrapper_props=None):
         self.element = element
-        self.props = props
+        self.props = props if props else {}
         self.wrapper = wrapper
         self.wrapper_props = wrapper_props
 

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -87,7 +87,12 @@ class WrapperState:
     def element_for(self, block):
         type_ = block.get('type', 'unstyled')
         depth = block.get('depth', 0)
+        block_data = block.get('data')
         options = Options.for_block(self.block_map, type_)
+
+        if block_data:
+            props = dict(options.props)
+            props['blockData'] = block_data
 
         # Make an element from the options specified in the block map.
         elt = DOM.create_element(options.element, options.props)

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -87,15 +87,16 @@ class WrapperState:
     def element_for(self, block):
         type_ = block.get('type', 'unstyled')
         depth = block.get('depth', 0)
-        block_data = block.get('data')
+        data = block.get('data', {})
         options = Options.for_block(self.block_map, type_)
-
-        if block_data:
-            props = dict(options.props)
-            props['blockData'] = block_data
+        props = dict(options.props)
+        props['block'] = {
+            'depth': depth,
+            'data': data,
+        }
 
         # Make an element from the options specified in the block map.
-        elt = DOM.create_element(options.element, options.props)
+        elt = DOM.create_element(options.element, props)
 
         parent = self.parent_for(options, depth, elt)
 
@@ -144,7 +145,12 @@ class WrapperState:
                 if len(wrapper_children) == 0:
                     # If there is no content in the current wrapper, we need
                     # to add an intermediary node.
-                    wrapper_parent = DOM.create_element(options.element, options.props)
+                    props = dict(options.props)
+                    props['block'] = {
+                        'data': {},
+                        'depth': depth,
+                    }
+                    wrapper_parent = DOM.create_element(options.element, props)
                     DOM.append_child(self.stack.head().elt, wrapper_parent)
                 else:
                     # Otherwise we can append at the end of the last child.

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -84,7 +84,7 @@ class WrapperState:
         if document_length == 0 and self.stack.length() != 0:
             DOM.append_child(self.document, self.stack.tail().elt)
 
-    def element_for(self, block):
+    def element_for(self, block, block_content):
         type_ = block.get('type', 'unstyled')
         depth = block.get('depth', 0)
         data = block.get('data', {})
@@ -96,7 +96,7 @@ class WrapperState:
         }
 
         # Make an element from the options specified in the block map.
-        elt = DOM.create_element(options.element, props)
+        elt = DOM.create_element(options.element, props, block_content)
 
         parent = self.parent_for(options, depth, elt)
 

--- a/example.py
+++ b/example.py
@@ -19,7 +19,7 @@ def Blockquote(props):
 
     return DOM.create_element('blockquote', {
         'cite': block_data.get('cite')
-    })
+    }, props['children'])
 
 
 def ListItem(props):
@@ -27,7 +27,7 @@ def ListItem(props):
 
     return DOM.create_element('li', {
         'class': 'list-item--depth-{0}'.format(depth)
-    })
+    }, props['children'])
 
 
 def HR(props):

--- a/example.py
+++ b/example.py
@@ -14,6 +14,22 @@ from draftjs_exporter.dom import DOM
 from draftjs_exporter.html import HTML
 
 
+def Blockquote(props):
+    block_data = props['block']['data']
+
+    return DOM.create_element('blockquote', {
+        'cite': block_data.get('cite')
+    })
+
+
+def ListItem(props):
+    depth = props['block']['depth']
+
+    return DOM.create_element('li', {
+        'class': 'list-item--depth-{0}'.format(depth)
+    })
+
+
 def HR(props):
     return DOM.create_element('hr')
 
@@ -82,13 +98,19 @@ config = {
         # The most basic mapping format, block type to tag name.
         BLOCK_TYPES.HEADER_TWO: 'h2',
         # Use a dict to define props on the block.
-        BLOCK_TYPES.BLOCKQUOTE: {'element': 'blockquote', 'props': {'className': 'pullquote'}},
+        BLOCK_TYPES.HEADER_THREE: {'element': 'h3', 'props': {'className': 'u-text-center'}},
         # Add a wrapper (and wrapper_props) to wrap adjacent blocks.
         BLOCK_TYPES.UNORDERED_LIST_ITEM: {
             'element': 'li',
             'wrapper': 'ul',
             'wrapper_props': {'className': 'bullet-list'},
         },
+        # Use a component for more flexibility (reading block data or depth).
+        BLOCK_TYPES.BLOCKQUOTE: Blockquote,
+        BLOCK_TYPES.ORDERED_LIST_ITEM: {
+            'element': ListItem,
+            'wrapper': 'ol',
+        }
     }),
     # `style_map` defines the HTML representation of inline elements.
     # Extend STYLE_MAP to start with sane defaults, or make your own from scratch.
@@ -154,10 +176,21 @@ content_state = {
             'entityRanges': []
         },
         {
+            'key': '6bvvh',
+            'text': 'Front-end (FED) development',
+            'type': 'header-three',
+            'depth': 0,
+            'inlineStyleRanges': [],
+            'entityRanges': []
+        },
+        {
             'key': '5384u',
             'text': 'Everyone 🍺 Springload applies the best #principles of UX to their work.',
             'type': 'blockquote',
             'depth': 0,
+            'data': {
+                'cite': 'http://example.com/',
+            },
             'inlineStyleRanges': [],
             'entityRanges': []
         },
@@ -172,7 +205,7 @@ content_state = {
         {
             'key': 'b9grk',
             'text': 'User research',
-            'type': 'unordered-list-item',
+            'type': 'ordered-list-item',
             'depth': 0,
             'inlineStyleRanges': [],
             'entityRanges': []
@@ -180,7 +213,7 @@ content_state = {
         {
             'key': 'a1tis',
             'text': 'User testing and analysis',
-            'type': 'unordered-list-item',
+            'type': 'ordered-list-item',
             'depth': 0,
             'inlineStyleRanges': [
                 {
@@ -200,24 +233,24 @@ content_state = {
         {
             'key': 'adjdn',
             'text': 'A/B testing',
-            'type': 'unordered-list-item',
-            'depth': 0,
+            'type': 'ordered-list-item',
+            'depth': 1,
             'inlineStyleRanges': [],
             'entityRanges': []
         },
         {
             'key': '62lio',
             'text': 'Prototyping',
-            'type': 'unordered-list-item',
-            'depth': 0,
+            'type': 'ordered-list-item',
+            'depth': 1,
             'inlineStyleRanges': [],
             'entityRanges': []
         },
         {
             'key': '62lio',
             'text': 'Beautiful <code/>',
-            'type': 'unordered-list-item',
-            'depth': 0,
+            'type': 'ordered-list-item',
+            'depth': 1,
             'inlineStyleRanges': [],
             'entityRanges': []
         },

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -7,7 +7,7 @@ from draftjs_exporter.options import ConfigException, Options
 
 class TestOptions(unittest.TestCase):
     def test_str(self):
-        self.assertEqual(str(Options('li')), '<Options li None None None>')
+        self.assertEqual(str(Options('li')), '<Options li {} None None>')
 
     def test_eq(self):
         self.assertEqual(Options('li'), Options('li'))

--- a/tests/test_wrapper_state.py
+++ b/tests/test_wrapper_state.py
@@ -6,6 +6,22 @@ from draftjs_exporter.dom import DOM
 from draftjs_exporter.wrapper_state import WrapperState
 
 
+def Blockquote(props):
+    block_data = props['block']['data']
+
+    return DOM.create_element('blockquote', {
+        'cite': block_data.get('cite')
+    }, props['children'])
+
+
+def ListItem(props):
+    depth = props['block']['depth']
+
+    return DOM.create_element('li', {
+        'class': 'list-item--depth-{0}'.format(depth)
+    }, props['children'])
+
+
 class TestWrapperState(unittest.TestCase):
     def setUp(self):
         self.wrapper_state = WrapperState({
@@ -13,6 +29,8 @@ class TestWrapperState(unittest.TestCase):
             'unstyled': 'div',
             'atomic': lambda props: props['children'],
             'ignore': None,
+            'blockquote': Blockquote,
+            'unordered-liste-item': ListItem,
         })
 
     def test_init(self):
@@ -58,6 +76,19 @@ class TestWrapperState(unittest.TestCase):
             'entityRanges': []
         }, DOM.create_element('img', {'src': '/example.png'}))), '<img src="/example.png"/>')
 
+    def test_element_for_component(self):
+        self.assertEqual(DOM.render(self.wrapper_state.element_for({
+            'key': '5s7g9',
+            'text': 'Paragraph',
+            'type': 'blockquote',
+            'depth': 0,
+            'data': {
+                'cite': 'http://example.com/',
+            },
+            'inlineStyleRanges': [],
+            'entityRanges': []
+        }, 'Test')), '<blockquote cite="http://example.com/">Test</blockquote>')
+
     def test_to_string_empty(self):
         self.assertEqual(self.wrapper_state.to_string(), '')
 
@@ -87,3 +118,23 @@ class TestWrapperState(unittest.TestCase):
         }, '')
 
         self.assertEqual(str(self.wrapper_state), '<WrapperState: <h1></h1>>')
+
+
+class TestBlockquote(unittest.TestCase):
+    def test_render(self):
+        self.assertEqual(DOM.render(DOM.create_element(Blockquote, {
+            'block': {
+                'data': {
+                    'cite': 'http://example.com/',
+                },
+            },
+        }, 'Test')), '<blockquote cite="http://example.com/">Test</blockquote>')
+
+
+class TestListItem(unittest.TestCase):
+    def test_render(self):
+        self.assertEqual(DOM.render(DOM.create_element(ListItem, {
+            'block': {
+                'depth': 5,
+            },
+        }, 'Test')), '<li class="list-item--depth-5">Test</li>')

--- a/tests/test_wrapper_state.py
+++ b/tests/test_wrapper_state.py
@@ -11,30 +11,52 @@ class TestWrapperState(unittest.TestCase):
         self.wrapper_state = WrapperState({
             'header-one': 'h1',
             'unstyled': 'div',
+            'atomic': lambda props: props['children'],
+            'ignore': None,
         })
 
     def test_init(self):
         self.assertIsInstance(self.wrapper_state, WrapperState)
 
-    def test_element_for_text(self):
-        self.assertEqual(DOM.get_text_content(self.wrapper_state.element_for({
+    def test_element_for_simple_content(self):
+        self.assertEqual(DOM.render(self.wrapper_state.element_for({
             'key': '5s7g9',
             'text': 'Header',
             'type': 'header-one',
             'depth': 0,
             'inlineStyleRanges': [],
             'entityRanges': []
-        })), None)
+        }, 'Header')), '<h1>Header</h1>')
 
-    def test_element_for_tag(self):
-        self.assertEqual(DOM.get_tag_name(self.wrapper_state.element_for({
+    def test_element_for_element_content(self):
+        self.assertEqual(DOM.render(self.wrapper_state.element_for({
             'key': '5s7g9',
-            'text': 'Header',
-            'type': 'header-one',
+            'text': 'Paragraph',
+            'type': 'unstyled',
             'depth': 0,
             'inlineStyleRanges': [],
             'entityRanges': []
-        })), 'h1')
+        }, DOM.create_element('strong', {}, 'Paragraph'))), '<div><strong>Paragraph</strong></div>')
+
+    def test_element_for_dismiss_content(self):
+        self.assertEqual(DOM.render(self.wrapper_state.element_for({
+            'key': '5s7g9',
+            'text': 'Paragraph',
+            'type': 'ignore',
+            'depth': 0,
+            'inlineStyleRanges': [],
+            'entityRanges': []
+        }, DOM.create_element('img', {'src': '/example.png'}))), '')
+
+    def test_element_for_no_block(self):
+        self.assertEqual(DOM.render(self.wrapper_state.element_for({
+            'key': '5s7g9',
+            'text': 'Paragraph',
+            'type': 'atomic',
+            'depth': 0,
+            'inlineStyleRanges': [],
+            'entityRanges': []
+        }, DOM.create_element('img', {'src': '/example.png'}))), '<img src="/example.png"/>')
 
     def test_to_string_empty(self):
         self.assertEqual(self.wrapper_state.to_string(), '')
@@ -47,7 +69,7 @@ class TestWrapperState(unittest.TestCase):
             'depth': 0,
             'inlineStyleRanges': [],
             'entityRanges': []
-        })
+        }, '')
 
         self.assertEqual(self.wrapper_state.to_string(), '<h1></h1>')
 
@@ -62,6 +84,6 @@ class TestWrapperState(unittest.TestCase):
             'depth': 0,
             'inlineStyleRanges': [],
             'entityRanges': []
-        })
+        }, '')
 
         self.assertEqual(str(self.wrapper_state), '<WrapperState: <h1></h1>>')


### PR DESCRIPTION
See https://github.com/springload/draftjs_exporter/issues/39

This change allows to specify element rendering in details, via following structure:

```python
class DirectSpeech:
    def render(self, props):
        data = props.get('data', {})
        name = data.get('name', None)

        return DOM.create_element(
            'div',
            {'some-attr': 'test'},
            DOM.create_element('h3', {}, name))

parsed_text = json.loads(text)

exporter = HTML({
    'block_map': {
        'direct-speech': {
            'element': DirectSpeech(),
            'wrapper': 'h1',
        },
        'unstyled': {'element': 'div'},
    },
})
text = exporter.render(parsed_text)
```

Things I like in this approach:
- it makes block data available to be used in components rendering;
- I think that it's also nice that the syntax is the same as for entity decorators components.

Things I **don't** like:
- children are appended to the root element I guess. It'd be great to pass them as prop to `render` function and let the developer choose where to put them.

The changes are not covered by tests, it's just a first draft.
