### PR TITLE
Fix block ordering with block components and wrapper. Fix #55

### DIFF
--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -116,10 +116,7 @@ class WrapperState:
             DOM.append_child(parent, elt)
         else:
             # Reset the stack if there is no wrapper.
-            head = self.stack.head()
-            if self.stack.length() > 0 and head.depth != -1 and head.props is not None:
-                self.stack.slice(-1)
-                self.stack.append(Wrapper(-1, None))
+            self.stack = WrapperStack()
             parent = elt
 
         return parent

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -20,15 +20,6 @@ def Blockquote(props):
     }, props['children'])
 
 
-def Pullquote(props):
-    block_data = props['block']['data']
-
-    return DOM.create_element('div', {
-        'cite': block_data.get('cite'),
-        'class': 'pullquote',
-    }, props['children'])
-
-
 config = {
     'entity_decorators': {
         ENTITY_TYPES.LINK: Link,
@@ -48,10 +39,6 @@ config = {
         },
         'blockquote': {
             'element': Blockquote,
-            'wrapper': 'div',
-        },
-        'pullquote': {
-            'element': Pullquote,
             'wrapper': 'div',
         },
     }),
@@ -605,7 +592,7 @@ class TestOutput(unittest.TestCase):
                 {
                     'key': 'c6gc3',
                     'text': '4',
-                    'type': 'pullquote',
+                    'type': 'blockquote',
                     'depth': 0,
                     'data': {
                         'cite': 'http://example.com/'

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -576,7 +576,7 @@ class TestOutput(unittest.TestCase):
                     'type': 'blockquote',
                     'depth': 0,
                     'data': {
-                        'cite': 'http://example.com/'
+                        'cite': '2'
                     },
                     'inlineStyleRanges': [],
                     'entityRanges': [],
@@ -595,7 +595,7 @@ class TestOutput(unittest.TestCase):
                     'type': 'blockquote',
                     'depth': 0,
                     'data': {
-                        'cite': 'http://example.com/'
+                        'cite': '4'
                     },
                     'inlineStyleRanges': [],
                     'entityRanges': [],
@@ -609,7 +609,7 @@ class TestOutput(unittest.TestCase):
                     'entityRanges': [],
                 },
             ],
-        }), '<p>1</p><ul class="steps"><li>2</li></ul><p>3</p><ul class="steps"><li>4</li></ul><p>5</p>')
+        }), '<p>1</p><div><blockquote cite="2">2</blockquote></div><p>3</p><div><blockquote cite="4">4</blockquote></div><p>5</p>')
 
     def test_render_with_unidirectional_nested_wrapping(self):
         self.assertEqual(self.exporter.render({

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -5,15 +5,35 @@ import unittest
 
 from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
 from draftjs_exporter.defaults import BLOCK_MAP
+from draftjs_exporter.dom import DOM
 from draftjs_exporter.entity_state import EntityException
 from draftjs_exporter.html import HTML
 from tests.test_composite_decorators import BR, Hashtag, Linkify
-from tests.test_entities import HR, Link
+from tests.test_entities import HR, Image, Link
+
+
+def Blockquote(props):
+    block_data = props['block']['data']
+
+    return DOM.create_element('blockquote', {
+        'cite': block_data.get('cite')
+    }, props['children'])
+
+
+def Pullquote(props):
+    block_data = props['block']['data']
+
+    return DOM.create_element('div', {
+        'cite': block_data.get('cite'),
+        'class': 'pullquote',
+    }, props['children'])
+
 
 config = {
     'entity_decorators': {
         ENTITY_TYPES.LINK: Link,
         ENTITY_TYPES.HORIZONTAL_RULE: HR,
+        ENTITY_TYPES.IMAGE: Image
     },
     'composite_decorators': [
         Linkify,
@@ -25,6 +45,14 @@ config = {
             'element': 'li',
             'wrapper': 'ul',
             'wrapper_props': {'className': 'steps'},
+        },
+        'blockquote': {
+            'element': Blockquote,
+            'wrapper': 'div',
+        },
+        'pullquote': {
+            'element': Pullquote,
+            'wrapper': 'div',
         },
     }),
     'style_map': {
@@ -495,6 +523,106 @@ class TestOutput(unittest.TestCase):
                 },
             ]
         }), '<ul class="steps"><li>item1</li><li>item2</li></ul><hr/>')
+
+    def test_render_with_wrapping_reset(self):
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'key': '93agv',
+                    'text': '1',
+                    'type': 'unstyled',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '4ht9m',
+                    'text': '2',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': 'c6gc4',
+                    'text': '3',
+                    'type': 'unstyled',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': 'c6gc3',
+                    'text': '4',
+                    'type': 'unordered-list-item',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '3mn5b',
+                    'text': '5',
+                    'type': 'unstyled',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+            ],
+        }), '<p>1</p><ul class="steps"><li>2</li></ul><p>3</p><ul class="steps"><li>4</li></ul><p>5</p>')
+
+    def test_render_with_wrapping_reset_block_components(self):
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'key': '93agv',
+                    'text': '1',
+                    'type': 'unstyled',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '4ht9m',
+                    'text': '2',
+                    'type': 'blockquote',
+                    'depth': 0,
+                    'data': {
+                        'cite': 'http://example.com/'
+                    },
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': 'c6gc4',
+                    'text': '3',
+                    'type': 'unstyled',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': 'c6gc3',
+                    'text': '4',
+                    'type': 'pullquote',
+                    'depth': 0,
+                    'data': {
+                        'cite': 'http://example.com/'
+                    },
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+                {
+                    'key': '3mn5b',
+                    'text': '5',
+                    'type': 'unstyled',
+                    'depth': 0,
+                    'inlineStyleRanges': [],
+                    'entityRanges': [],
+                },
+            ],
+        }), '<p>1</p><ul class="steps"><li>2</li></ul><p>3</p><ul class="steps"><li>4</li></ul><p>5</p>')
 
     def test_render_with_unidirectional_nested_wrapping(self):
         self.assertEqual(self.exporter.render({


### PR DESCRIPTION
Fix for #55. The wrapper stack reset wasn't up to date, and for some reason this particular scenario is one of the rare cases where the behaviour would be incorrect.