### PR TITLE
Performance refactorings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,7 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
     return NotImplemented
+    except NameError:
 
     # Don't complain if non-runnable code isn't run:
     if 0:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,12 +17,11 @@ else
     # Fail on first line that fails.
     set -e
 
-    NEW_FILES=$(git --no-pager diff --name-only --cached)
+    NEW_FILES=$(git --no-pager diff --name-only --cached --diff-filter=d)
     PY_FILES=$(echo "$NEW_FILES" | { grep .py || true; })
 
     if [ -n "$PY_FILES" ];
     then
-        make lint
         make test-ci
     fi
     exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
    - env: TOXENV=py35
      python: 3.5
 install:
-- pip install coveralls
+- pip install tox coveralls
 script:
 - make test-ci
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ matrix:
    - env: TOXENV=py35
      python: 3.5
 install:
-- pip install tox coveralls
+- make init
+- pip install coveralls
 script:
 - make test-ci
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
    - env: TOXENV=py35
      python: 3.5
 install:
-- make init
 - pip install coveralls
 script:
 - make test-ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ KEYBOARD = 'kbd'
 - By default, `code-block` blocks are now rendered inside a combination of `pre` and `code` tags.
 - For entities, directly pass `data` dict as props instead of whole entity map declaration.
 
+### Fixed
+
+- Fix block ordering with block components and wrapper. Fix #55.
+
 ### How to upgrade
 
 ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ KEYBOARD = 'kbd'
 ### Removed
 
 - Remove array-style block element and wrapper declarations (`['ul']`, `['ul', {'className': 'bullet-list'}]`).
+- Remove `DOM.create_text_node` method.
 
 ### Changed
 
@@ -97,6 +98,15 @@ KEYBOARD = 'kbd'
 -         'href': data['url'],
 +         'href': props['url'],
       }
+# Remove wrapping around text items.
+- DOM.create_text_node(text)
++ text
+# Remove fragment calls.
+- DOM.create_document_fragment()
++ DOM.create_element()
+# Remove text getters and setters. This is not supported anymore.
+- DOM.get_text_content(elt)
+- DOM.set_text_content(elt, text)
 ```
 
 ## [v0.7.0](https://github.com/springload/draftjs_exporter/releases/tag/v0.7.0)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ help: ## See what commands are available.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36mmake %-15s\033[0m # %s\n", $$1, $$2}'
 
 init: clean-pyc ## Install dependencies and initialise for development.
-	pip install -e .[testing,docs] -U
+	pip install --upgrade pip
+	pip install -e '.[testing,docs]' -U
 
 lint: ## Lint the project.
 	flake8 draftjs_exporter tests example.py setup.py

--- a/README.rst
+++ b/README.rst
@@ -199,8 +199,11 @@ Installation
     virtualenv .venv
     source ./.venv/bin/activate
     make init
-    # Install all tested python versions.
-    pyenv install 2.7.11 && pyenv install 3.4.4 && pyenv install 3.5.1
+    # Install required Python versions
+    pyenv install --skip-existing 2.7.11
+	pyenv install --skip-existing 3.4.4
+	pyenv install --skip-existing 3.5.1
+    # Make required Python versions available globally.
     pyenv global system 2.7.11 3.4.4 3.5.1
 
 Commands

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -43,8 +43,8 @@ class Command:
         """
         commands = []
         for r in ranges:
-            data = r.get(data_key)
-            start = r.get(start_key)
-            stop = start + r.get(length_key)
+            data = r[data_key]
+            start = r[start_key]
+            stop = start + r[length_key]
             commands.extend(Command.start_stop(name, start, stop, data))
         return commands

--- a/draftjs_exporter/composite_decorators.py
+++ b/draftjs_exporter/composite_decorators.py
@@ -27,7 +27,7 @@ def apply_decorators(decorators, text, block_type):
     pointer = 0
     for begin, end, match, decorator in decorations:
         if pointer < begin:
-            yield DOM.create_text_node(text[pointer:begin])
+            yield text[pointer:begin]
 
         yield DOM.create_element(decorator, {
             'match': match,
@@ -36,7 +36,7 @@ def apply_decorators(decorators, text, block_type):
         pointer = end
 
     if pointer < len(text):
-        yield DOM.create_text_node(text[pointer:])
+        yield text[pointer:]
 
 
 def render_decorators(decorators, text, block_type):
@@ -45,7 +45,7 @@ def render_decorators(decorators, text, block_type):
     if len(decorated_children) == 1:
         decorated_node = decorated_children[0]
     else:
-        decorated_node = DOM.create_document_fragment()
+        decorated_node = DOM.create_element()
         for decorated_child in decorated_children:
             DOM.append_child(decorated_node, decorated_child)
 

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -28,17 +28,17 @@ def Soup(raw_str):
 soup = Soup('')
 
 
-class DOM(object):
+def create_tag(type_, attributes=None):
     """
     Wrapper around our HTML building library to facilitate changes.
     """
-    @staticmethod
-    def create_tag(type_, attributes=None):
-        if attributes is None:
-            attributes = {}
+    if attributes is None:
+        attributes = {}
 
-        return soup.new_tag(type_, **attributes)
+    return soup.new_tag(type_, **attributes)
 
+
+class DOM(object):
     @staticmethod
     def create_element(type_=None, props=None, *children):
         """
@@ -93,7 +93,7 @@ class DOM(object):
                 # Never render block attribute on a raw tag.
                 attributes.pop('block', None)
 
-                elt = DOM.create_tag(type_, attributes)
+                elt = create_tag(type_, attributes)
 
                 for child in children:
                     if child:
@@ -106,11 +106,11 @@ class DOM(object):
 
     @staticmethod
     def create_document_fragment():
-        return DOM.create_tag('fragment')
+        return create_tag('fragment')
 
     @staticmethod
     def create_text_node(text):
-        elt = DOM.create_tag('textnode')
+        elt = create_tag('textnode')
         DOM.set_text_content(elt, text)
         return elt
 
@@ -127,18 +127,6 @@ class DOM(object):
     @staticmethod
     def append_child(elt, child):
         elt.append(child)
-
-    @staticmethod
-    def set_attribute(elt, attr, value):
-        elt[attr] = value
-
-    @staticmethod
-    def get_tag_name(elt):
-        return elt.name
-
-    @staticmethod
-    def get_class_list(elt):
-        return elt.get('class', [])
 
     @staticmethod
     def get_text_content(elt):
@@ -161,6 +149,10 @@ class DOM(object):
         Dirty, but quite easy to understand.
         """
         return re.sub(r'</?(fragment|textnode|body|html|head)>', '', unicode(elt)).strip()
+
+    @staticmethod
+    def render_debug(elt):
+        return re.sub(r'</?(body|html|head)>', '', unicode(elt)).strip()
 
     @staticmethod
     def pretty_print(markup):

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -38,6 +38,18 @@ def create_tag(type_, attributes=None):
     return soup.new_tag(type_, **attributes)
 
 
+def create_document_fragment():
+        return create_tag('fragment')
+
+
+def get_text_content(elt):
+        return elt.string
+
+
+def set_text_content(elt, text):
+        elt.append(text)
+
+
 class DOM(object):
     @staticmethod
     def create_element(type_=None, props=None, *children):
@@ -51,7 +63,7 @@ class DOM(object):
         https://facebook.github.io/react/docs/top-level-api.html#react.createelement
         """
         if not type_:
-            elt = DOM.create_document_fragment()
+            elt = create_document_fragment()
         else:
             if props is None:
                 props = {}
@@ -100,18 +112,8 @@ class DOM(object):
                         if hasattr(child, 'tag'):
                             DOM.append_child(elt, child)
                         else:
-                            DOM.set_text_content(elt, DOM.get_text_content(elt) + child if DOM.get_text_content(elt) else child)
+                            set_text_content(elt, get_text_content(elt) + child if get_text_content(elt) else child)
 
-        return elt
-
-    @staticmethod
-    def create_document_fragment():
-        return create_tag('fragment')
-
-    @staticmethod
-    def create_text_node(text):
-        elt = create_tag('textnode')
-        DOM.set_text_content(elt, text)
         return elt
 
     @staticmethod
@@ -129,14 +131,6 @@ class DOM(object):
         elt.append(child)
 
     @staticmethod
-    def get_text_content(elt):
-        return elt.string
-
-    @staticmethod
-    def set_text_content(elt, text):
-        elt.string = text
-
-    @staticmethod
     def get_children(elt):
         return list(elt.children)
 
@@ -148,7 +142,7 @@ class DOM(object):
         better way to do this.
         Dirty, but quite easy to understand.
         """
-        return re.sub(r'</?(fragment|textnode|body|html|head)>', '', unicode(elt)).strip()
+        return re.sub(r'</?(fragment|body|html|head)>', '', unicode(elt)).strip()
 
     @staticmethod
     def render_debug(elt):

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -19,57 +19,49 @@ class EntityState:
 
     def apply(self, command):
         if command.name == 'start_entity':
-            self.start_command(command)
+            self.entity_stack.append(command.data)
         elif command.name == 'stop_entity':
-            self.stop_command(command)
+            expected_entity = self.entity_stack[-1]
+
+            if command.data != expected_entity:
+                raise EntityException('Expected {0}, got {1}'.format(expected_entity, command.data))
+
+            self.completed_entity = self.entity_stack.pop()
 
     def has_no_entity(self):
         return not self.entity_stack
 
-    def get_entity_details(self, command):
-        key = str(command.data)
-        details = self.entity_map.get(key)
+    def get_entity_details(self, entity_key):
+        details = self.entity_map.get(str(entity_key))
 
         if details is None:
-            raise EntityException('Entity "%s" does not exist in the entityMap' % key)
+            raise EntityException('Entity "%s" does not exist in the entityMap' % entity_key)
 
         return details
 
-    def get_entity_decorator(self, entity_details):
-        type_ = entity_details.get('type')
-
+    def get_entity_decorator(self, type_):
         if type_ not in self.entity_decorators:
             raise EntityException('Decorator "%s" does not exist in entity_decorators' % type_)
 
-        decorator = self.entity_decorators.get(type_)
+        decorator = self.entity_decorators[type_]
 
         return decorator
 
-    def start_command(self, command):
-        entity_details = self.get_entity_details(command)
-        self.entity_stack.append(entity_details)
-
-    def stop_command(self, command):
-        entity_details = self.get_entity_details(command)
-        expected_entity_details = self.entity_stack[-1]
-
-        if expected_entity_details != entity_details:
-            raise EntityException('Expected {0}, got {1}'.format(expected_entity_details, entity_details))
-
-        self.completed_entity = self.entity_stack.pop()
-
     def render_entitities(self, style_node):
 
-        if self.completed_entity:
+        if self.completed_entity is not None:
             # self.element_stack.append(style_node)
-            decorator = self.get_entity_decorator(self.completed_entity)
-            props = self.completed_entity.get('data').copy()
+            entity_details = self.get_entity_details(self.completed_entity)
+            decorator = self.get_entity_decorator(entity_details['type'])
+            props = entity_details['data'].copy()
 
             nodes = DOM.create_document_fragment()
+
             for n in self.element_stack:
                 DOM.append_child(nodes, n)
 
             elt = DOM.create_element(decorator, props, nodes)
+
             self.completed_entity = None
             self.element_stack = []
         elif self.has_no_entity():

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -55,7 +55,7 @@ class EntityState:
             decorator = self.get_entity_decorator(entity_details['type'])
             props = entity_details['data'].copy()
 
-            nodes = DOM.create_document_fragment()
+            nodes = DOM.create_element()
 
             for n in self.element_stack:
                 DOM.append_child(nodes, n)

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -33,23 +33,22 @@ class HTML:
         self.wrapper_state = WrapperState(self.block_map)
         self.document = DOM.create_document_fragment()
         entity_map = content_state['entityMap']
+        min_depth = 0
 
         for block in content_state['blocks']:
             depth = block['depth']
             elt = self.render_block(block, entity_map)
 
+            if depth > min_depth:
+                min_depth = depth
+
             # At level 0, the element is added to the document.
             if depth == 0:
                 DOM.append_child(self.document, elt)
 
-        """
-        Special method to handle a rare corner case: if there is no block
-        at depth 0, we need to add the wrapper that contains the whole
-        tree to the document.
-        """
-        document_length = len(DOM.get_children(self.document))
-
-        if document_length == 0 and self.wrapper_state.stack.length() != 0:
+        # If there is no block at depth 0, we need to add the wrapper that contains the whole tree to the document.
+        # TODO This might not be enough when specific wrappers never reach 0.
+        if min_depth > 0 and self.wrapper_state.stack.length() != 0:
             DOM.append_child(self.document, self.wrapper_state.stack.tail().elt)
 
         return DOM.render(self.document)

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -32,9 +32,9 @@ class HTML:
         """
         self.wrapper_state = WrapperState(self.block_map)
         self.document = DOM.create_document_fragment()
-        entity_map = content_state.get('entityMap', {})
+        entity_map = content_state['entityMap']
 
-        for block in content_state.get('blocks', []):
+        for block in content_state['blocks']:
             depth = block['depth']
             elt = self.render_block(block, entity_map)
 
@@ -66,7 +66,7 @@ class HTML:
 
             # Decorators are not rendered inside entities.
             if entity_state.has_no_entity() and len(self.composite_decorators) > 0:
-                decorated_node = render_decorators(self.composite_decorators, text, block.get('type', None))
+                decorated_node = render_decorators(self.composite_decorators, text, block['type'])
             else:
                 decorated_node = DOM.create_text_node(text)
 
@@ -83,7 +83,7 @@ class HTML:
         Creates block modification commands, grouped by start index,
         with the text to apply them on.
         """
-        text = block.get('text')
+        text = block['text']
 
         commands = sorted(self.build_commands(block))
         grouped = groupby(commands, Command.key)
@@ -108,16 +108,16 @@ class HTML:
         - Multiple pairs for styles.
         - Multiple pairs for entities.
         """
-        text_commands = Command.start_stop('text', 0, len(block.get('text')))
+        text_commands = Command.start_stop('text', 0, len(block['text']))
         style_commands = self.build_style_commands(block)
         entity_commands = self.build_entity_commands(block)
 
         return text_commands + style_commands + entity_commands
 
     def build_style_commands(self, block):
-        ranges = block.get('inlineStyleRanges', [])
+        ranges = block['inlineStyleRanges']
         return Command.from_ranges(ranges, 'inline_style', 'style')
 
     def build_entity_commands(self, block):
-        ranges = block.get('entityRanges', [])
+        ranges = block['entityRanges']
         return Command.from_ranges(ranges, 'entity', 'key')

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -31,7 +31,7 @@ class HTML:
         Starts the export process on a given piece of content state.
         """
         self.wrapper_state = WrapperState(self.block_map)
-        self.document = DOM.create_document_fragment()
+        self.document = DOM.create_element()
         entity_map = content_state['entityMap']
         min_depth = 0
 
@@ -54,7 +54,7 @@ class HTML:
         return DOM.render(self.document)
 
     def render_block(self, block, entity_map):
-        content = DOM.create_document_fragment()
+        content = DOM.create_element()
         entity_state = EntityState(self.entity_decorators, entity_map)
         style_state = StyleState(self.style_map)
 

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -68,13 +68,14 @@ class HTML:
             if entity_state.has_no_entity() and len(self.composite_decorators) > 0:
                 decorated_node = render_decorators(self.composite_decorators, text, block['type'])
             else:
-                decorated_node = DOM.create_text_node(text)
+                decorated_node = text
 
             styled_node = style_state.render_styles(decorated_node)
             entity_node = entity_state.render_entitities(styled_node)
             if entity_node:
                 DOM.append_child(content, entity_node)
-                DOM.append_child(content, styled_node)
+                if styled_node != entity_node:
+                    DOM.append_child(content, styled_node)
 
         return self.wrapper_state.element_for(block, content)
 

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -26,11 +26,9 @@ class StyleState:
     def render_styles(self, text_node):
         node = text_node
         if not self.is_empty():
-            self.styles.sort(reverse=True)
-            options = [Options.for_style(self.style_map, s) for s in self.styles]
-
             # Nest the tags.
-            for opt in options:
+            for s in sorted(self.styles, reverse=True):
+                opt = Options.for_style(self.style_map, s)
                 node = DOM.create_element(opt.element, opt.props, node)
 
         return node

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -13,6 +13,9 @@ class WrapperStack:
     def __init__(self):
         self.stack = []
 
+    def __str__(self):
+        return str(self.stack)
+
     def length(self):
         return len(self.stack)
 
@@ -67,30 +70,14 @@ class WrapperState:
 
     def __init__(self, block_map):
         self.block_map = block_map
-        self.document = DOM.create_document_fragment()
-
         self.stack = WrapperStack()
 
     def __str__(self):
-        return '<WrapperState: %s>' % self.to_string()
-
-    def to_string(self):
-        return DOM.render(self.document)
-
-    def clean_up(self):
-        """
-        Special method to handle a rare corner case: if there is no block
-        at depth 0, we need to add the wrapper that contains the whole
-        tree to the document.
-        """
-        document_length = len(DOM.get_children(self.document))
-
-        if document_length == 0 and self.stack.length() != 0:
-            DOM.append_child(self.document, self.stack.tail().elt)
+        return '<WrapperState: %s>' % self.stack
 
     def element_for(self, block, block_content):
-        type_ = block.get('type', 'unstyled')
-        depth = block.get('depth', 0)
+        type_ = block['type']
+        depth = block['depth']
         data = block.get('data', {})
         options = Options.for_block(self.block_map, type_)
         props = dict(options.props)
@@ -104,11 +91,7 @@ class WrapperState:
 
         parent = self.parent_for(options, depth, elt)
 
-        # At level 0, the element is added to the document.
-        if depth == 0:
-            DOM.append_child(self.document, parent)
-
-        return elt
+        return parent
 
     def parent_for(self, options, depth, elt):
         if options.wrapper:

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -30,14 +30,14 @@ class WrapperStack:
 
     def head(self):
         if self.length() > 0:
-            wrapper = self.get(-1)
+            wrapper = self.stack[-1]
         else:
             wrapper = Wrapper(-1)
 
         return wrapper
 
     def tail(self):
-        return self.get(0)
+        return self.stack[0]
 
 
 class Wrapper:

--- a/example.py
+++ b/example.py
@@ -100,7 +100,7 @@ class Linkify:
     SEARCH_RE = re.compile(r'(http://|https://|www\.)([a-zA-Z0-9\.\-%/\?&_=\+#:~!,\'\*\^$]+)')
 
     def render(self, props):
-        match = props.get('match')
+        match = props['match']
         protocol = match.group(1)
         url = match.group(2)
         href = protocol + url

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 install_requires = [
-    'beautifulsoup4>=4.4.1',
+    'beautifulsoup4>=4.4.1,<5',
     'html5lib>=0.999,<=0.9999999',
 ]
 
@@ -53,11 +53,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Internet :: WWW/HTTP :: Site Management',

--- a/tests/test_composite_decorators.py
+++ b/tests/test_composite_decorators.py
@@ -20,7 +20,7 @@ class Linkify:
         self.use_new_window = use_new_window
 
     def render(self, props):
-        match = props.get('match')
+        match = props['match']
         protocol = match.group(1)
         url = match.group(2)
         href = protocol + url

--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -17,29 +17,28 @@ class TestDOM(unittest.TestCase):
         self.assertEqual(DOM.render(DOM.create_element('p', {'style': 'border-color: red;text-decoration: underline;'}, 'Test test')), '<p style="border-color: red;text-decoration: underline;">Test test</p>')
 
     def test_create_element_empty(self):
-        self.assertEqual(DOM.get_tag_name(DOM.create_element()), 'fragment')
+        self.assertEqual(DOM.render_debug(DOM.create_element()), '<fragment></fragment>')
 
     def test_create_element_nested(self):
-        self.assertEqual(DOM.render(DOM.create_element('a', {}, DOM.create_element('span', {'className': 'file-info icon-text'}, DOM.create_element('span', {'className': 'icon-text__text'}, 'Test test'), DOM.create_element('svg', {'className': 'icon'}, DOM.create_element('use', {'xlink:href': '#icon-test'}))))), '<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xlink:href="#icon-test"></use></svg></span></a>')
+        self.assertEqual(DOM.render_debug(DOM.create_element('a', {}, DOM.create_element('span', {'className': 'file-info icon-text'}, DOM.create_element('span', {'className': 'icon-text__text'}, 'Test test'), DOM.create_element('svg', {'className': 'icon'}, DOM.create_element('use', {'xlink:href': '#icon-test'}))))), '<a><span class="file-info icon-text"><span class="icon-text__text">Test test</span><svg class="icon"><use xlink:href="#icon-test"></use></svg></span></a>')
 
     def test_create_element_none(self):
-        self.assertEqual(DOM.render(DOM.create_element('a', {}, None, DOM.create_element('span', {}, 'Test test'))), '<a><span>Test test</span></a>')
+        self.assertEqual(DOM.render_debug(DOM.create_element('a', {}, None, DOM.create_element('span', {}, 'Test test'))), '<a><span>Test test</span></a>')
 
     def test_create_element_entity(self):
-        self.assertEqual(DOM.render(DOM.create_element(Icon, {'name': 'rocket'})), '<svg class="icon"><use xlink:href="#icon-rocket"></use></svg>')
+        self.assertEqual(DOM.render_debug(DOM.create_element(Icon, {'name': 'rocket'})), '<svg class="icon"><use xlink:href="#icon-rocket"></use></svg>')
 
     def test_create_element_entity_configured(self):
-        self.assertEqual(DOM.render(DOM.create_element(Icon(icon_class='i'), {'name': 'rocket'})), '<svg class="i"><use xlink:href="#icon-rocket"></use></svg>')
+        self.assertEqual(DOM.render_debug(DOM.create_element(Icon(icon_class='i'), {'name': 'rocket'})), '<svg class="i"><use xlink:href="#icon-rocket"></use></svg>')
 
     def test_create_document_fragment(self):
-        self.assertEqual(DOM.get_tag_name(DOM.create_document_fragment()), 'fragment')
+        self.assertEqual(DOM.render_debug(DOM.create_document_fragment()), '<fragment></fragment>')
 
     def test_create_text_node(self):
-        self.assertEqual(DOM.get_tag_name(DOM.create_text_node('Test text')), 'textnode')
-        self.assertEqual(DOM.get_text_content(DOM.create_text_node('Test text')), 'Test text')
+        self.assertEqual(DOM.render_debug(DOM.create_text_node('Test text')), '<textnode>Test text</textnode>')
 
     def test_parse_html(self):
-        self.assertEqual(DOM.render(DOM.parse_html('<p><span>Test text</span></p>')), '<p><span>Test text</span></p>')
+        self.assertEqual(DOM.render_debug(DOM.parse_html('<p><span>Test text</span></p>')), '<p><span>Test text</span></p>')
 
     def test_camel_to_dash(self):
         self.assertEqual(DOM.camel_to_dash('testCamelToDash'), 'test-camel-to-dash')
@@ -52,18 +51,7 @@ class TestDOM(unittest.TestCase):
     def test_append_child(self):
         parent = DOM.create_element('p')
         DOM.append_child(parent, DOM.create_element('span', {}, 'Test text'))
-        self.assertEqual(DOM.render(parent), '<p><span>Test text</span></p>')
-
-    def test_set_attribute(self):
-        elt = DOM.create_element('a')
-        DOM.set_attribute(elt, 'href', 'http://example.com')
-        self.assertEqual(DOM.render(elt), '<a href="http://example.com"></a>')
-
-    def test_get_tag_name(self):
-        self.assertEqual(DOM.get_tag_name(DOM.create_element('p', {}, 'Test test')), 'p')
-
-    def test_get_class_list(self):
-        self.assertEqual(DOM.get_class_list(DOM.create_element('p', {'className': 'intro test'}, 'Test test')), ['intro', 'test'])
+        self.assertEqual(DOM.render_debug(parent), '<p><span>Test text</span></p>')
 
     def test_get_text_content(self):
         self.assertEqual(DOM.get_text_content(DOM.create_element('p', {}, 'Test test')), 'Test test')

--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -31,12 +31,6 @@ class TestDOM(unittest.TestCase):
     def test_create_element_entity_configured(self):
         self.assertEqual(DOM.render_debug(DOM.create_element(Icon(icon_class='i'), {'name': 'rocket'})), '<svg class="i"><use xlink:href="#icon-rocket"></use></svg>')
 
-    def test_create_document_fragment(self):
-        self.assertEqual(DOM.render_debug(DOM.create_document_fragment()), '<fragment></fragment>')
-
-    def test_create_text_node(self):
-        self.assertEqual(DOM.render_debug(DOM.create_text_node('Test text')), '<textnode>Test text</textnode>')
-
     def test_parse_html(self):
         self.assertEqual(DOM.render_debug(DOM.parse_html('<p><span>Test text</span></p>')), '<p><span>Test text</span></p>')
 
@@ -52,14 +46,6 @@ class TestDOM(unittest.TestCase):
         parent = DOM.create_element('p')
         DOM.append_child(parent, DOM.create_element('span', {}, 'Test text'))
         self.assertEqual(DOM.render_debug(parent), '<p><span>Test text</span></p>')
-
-    def test_get_text_content(self):
-        self.assertEqual(DOM.get_text_content(DOM.create_element('p', {}, 'Test test')), 'Test test')
-
-    def test_set_text_content(self):
-        elt = DOM.create_element('p')
-        DOM.set_text_content(elt, 'Test test')
-        self.assertEqual(DOM.get_text_content(elt), 'Test test')
 
     def test_get_children(self):
         self.assertEqual(len(DOM.get_children(DOM.create_element('span', {}, DOM.create_element('span'), DOM.create_element('span')))), 2)

--- a/tests/test_dom.py
+++ b/tests/test_dom.py
@@ -57,7 +57,7 @@ class TestDOM(unittest.TestCase):
     def test_set_attribute(self):
         elt = DOM.create_element('a')
         DOM.set_attribute(elt, 'href', 'http://example.com')
-        self.assertEqual(elt.get('href'), 'http://example.com')
+        self.assertEqual(DOM.render(elt), '<a href="http://example.com"></a>')
 
     def test_get_tag_name(self):
         self.assertEqual(DOM.get_tag_name(DOM.create_element('p', {}, 'Test test')), 'p')

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -31,19 +31,18 @@ class TestEntityState(unittest.TestCase):
     def test_apply_start_entity(self):
         self.assertEqual(len(self.entity_state.entity_stack), 0)
         self.entity_state.apply(Command('start_entity', 0, 0))
-        self.assertEqual(self.entity_state.entity_stack[-1], {
-            'data': {
-                'url': 'http://example.com'
-            },
-            'type': 'LINK',
-            'mutability': 'MUTABLE',
-        })
+        self.assertEqual(self.entity_state.entity_stack[-1], 0)
 
     def test_apply_stop_entity(self):
         self.assertEqual(len(self.entity_state.entity_stack), 0)
         self.entity_state.apply(Command('start_entity', 0, 0))
         self.entity_state.apply(Command('stop_entity', 5, 0))
         self.assertEqual(len(self.entity_state.entity_stack), 0)
+
+    def test_apply_raises(self):
+        with self.assertRaises(EntityException):
+            self.entity_state.apply(Command('start_entity', 0, 0))
+            self.entity_state.apply(Command('stop_entity', 0, 1))
 
     def test_has_no_entity_default(self):
         self.assertEqual(self.entity_state.has_no_entity(), True)
@@ -53,7 +52,7 @@ class TestEntityState(unittest.TestCase):
         self.assertEqual(self.entity_state.has_no_entity(), False)
 
     def test_get_entity_details(self):
-        self.assertEqual(self.entity_state.get_entity_details(Command('start_entity', 0, 0)), {
+        self.assertEqual(self.entity_state.get_entity_details(0), {
             'data': {
                 'url': 'http://example.com'
             },
@@ -63,31 +62,11 @@ class TestEntityState(unittest.TestCase):
 
     def test_get_entity_details_raises(self):
         with self.assertRaises(EntityException):
-            self.entity_state.get_entity_details(Command('start_entity', 0, 1))
+            self.entity_state.get_entity_details(1)
 
     def test_get_entity_decorator(self):
-        self.assertIsInstance(self.entity_state.get_entity_decorator({
-            'data': {
-                'url': 'http://example.com'
-            },
-            'type': 'LINK',
-            'mutability': 'MUTABLE',
-        }), Link)
+        self.assertIsInstance(self.entity_state.get_entity_decorator('LINK'), Link)
 
     def test_get_entity_decorator_raises(self):
         with self.assertRaises(EntityException):
-            self.entity_state.get_entity_decorator({
-                'data': {
-                    'url': 'http://example.com'
-                },
-                'type': 'VIDEO',
-                'mutability': 'MUTABLE',
-            })
-
-    def test_start_command_raises(self):
-        with self.assertRaises(EntityException):
-            self.entity_state.start_command(Command('start_entity', 0, 1))
-
-    def test_stop_command_raises(self):
-        with self.assertRaises(EntityException):
-            self.entity_state.start_command(Command('stop_entity', 0, 1))
+            self.entity_state.get_entity_decorator('VIDEO')

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -49,11 +49,11 @@ class TestExportsMeta(type):
         def gen_test(export):
             def test(self):
                 self.maxDiff = None
-                self.assertEqual(exporter.render(export.get('content_state')), export.get('output'))
+                self.assertEqual(exporter.render(export['content_state']), export['output'])
             return test
 
         for export in fixtures:
-            test_name = 'test_export_%s' % export.get('label').lower().replace(' ', '_')
+            test_name = 'test_export_%s' % export['label'].lower().replace(' ', '_')
             dict[test_name] = gen_test(export)
 
         return type.__new__(mcs, name, bases, dict)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1152,7 +1152,9 @@ class TestOutput(unittest.TestCase):
                     'key': '34a12',
                     'text': '#check www.example.com',
                     'type': 'code-block',
+                    'depth': 0,
                     'inlineStyleRanges': [],
+                    'entityRanges': [],
                 },
             ]
         }),

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -5,20 +5,11 @@ import unittest
 
 from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
 from draftjs_exporter.defaults import BLOCK_MAP
-from draftjs_exporter.dom import DOM
 from draftjs_exporter.entity_state import EntityException
 from draftjs_exporter.html import HTML
 from tests.test_composite_decorators import BR, Hashtag, Linkify
 from tests.test_entities import HR, Image, Link
-
-
-def Blockquote(props):
-    block_data = props['block']['data']
-
-    return DOM.create_element('blockquote', {
-        'cite': block_data.get('cite')
-    }, props['children'])
-
+from tests.test_wrapper_state import Blockquote
 
 config = {
     'entity_decorators': {
@@ -67,9 +58,6 @@ class TestOutput(unittest.TestCase):
             'entityMap': {},
             'blocks': []
         }), '')
-
-    def test_render_emptiest(self):
-        self.assertEqual(self.exporter.render({}), '')
 
     def test_render_with_different_blocks(self):
         self.assertEqual(self.exporter.render({

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -55,11 +55,10 @@ class TestStyleState(unittest.TestCase):
         self.assertEqual(self.style_state.is_empty(), False)
 
     def test_render_styles_unstyled(self):
-        self.assertEqual(DOM.get_tag_name(self.style_state.render_styles(DOM.create_text_node('Test text'))), 'textnode')
-        self.assertEqual(DOM.get_text_content(self.style_state.render_styles(DOM.create_text_node('Test text'))), 'Test text')
+        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), 'Test text')
 
     def test_render_styles_unicode(self):
-        self.assertEqual(DOM.get_text_content(self.style_state.render_styles(DOM.create_text_node('🍺'))), '🍺')
+        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('🍺'))), '🍺')
 
     def test_render_styles_styled(self):
         self.style_state.apply(Command('start_inline_style', 0, 'ITALIC'))

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -55,41 +55,41 @@ class TestStyleState(unittest.TestCase):
         self.assertEqual(self.style_state.is_empty(), False)
 
     def test_render_styles_unstyled(self):
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), 'Test text')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), 'Test text')
 
     def test_render_styles_unicode(self):
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('🍺'))), '🍺')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('🍺')), '🍺')
 
     def test_render_styles_styled(self):
         self.style_state.apply(Command('start_inline_style', 0, 'ITALIC'))
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), '<em>Test text</em>')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), '<em>Test text</em>')
         self.style_state.apply(Command('stop_inline_style', 9, 'ITALIC'))
 
     def test_render_styles_styled_multiple(self):
         self.style_state.apply(Command('start_inline_style', 0, 'BOLD'))
         self.style_state.apply(Command('start_inline_style', 0, 'ITALIC'))
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), '<strong><em>Test text</em></strong>')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), '<strong><em>Test text</em></strong>')
 
     def test_render_styles_attributes(self):
         self.style_state.apply(Command('start_inline_style', 0, 'KBD'))
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), '<kbd class="o-keyboard-shortcut">Test text</kbd>')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), '<kbd class="o-keyboard-shortcut">Test text</kbd>')
         self.style_state.apply(Command('stop_inline_style', 9, 'KBD'))
 
     def test_render_styles_component(self):
         self.style_state.apply(Command('start_inline_style', 0, 'IMPORTANT'))
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), '<strong style="color: red;">Test text</strong>')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), '<strong style="color: red;">Test text</strong>')
         self.style_state.apply(Command('stop_inline_style', 9, 'IMPORTANT'))
 
     def test_render_styles_component_multiple(self):
         self.style_state.apply(Command('start_inline_style', 0, 'IMPORTANT'))
         self.style_state.apply(Command('start_inline_style', 0, 'SHOUT'))
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), '<strong style="color: red;"><span style="text-transform: uppercase;">Test text</span></strong>')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), '<strong style="color: red;"><span style="text-transform: uppercase;">Test text</span></strong>')
         self.style_state.apply(Command('stop_inline_style', 9, 'IMPORTANT'))
         self.style_state.apply(Command('stop_inline_style', 9, 'SHOUT'))
 
     def test_render_styles_component_multiple_invert(self):
         self.style_state.apply(Command('start_inline_style', 0, 'SHOUT'))
         self.style_state.apply(Command('start_inline_style', 0, 'IMPORTANT'))
-        self.assertEqual(DOM.render(self.style_state.render_styles(DOM.create_text_node('Test text'))), '<strong style="color: red;"><span style="text-transform: uppercase;">Test text</span></strong>')
+        self.assertEqual(DOM.render_debug(self.style_state.render_styles('Test text')), '<strong style="color: red;"><span style="text-transform: uppercase;">Test text</span></strong>')
         self.style_state.apply(Command('stop_inline_style', 9, 'SHOUT'))
         self.style_state.apply(Command('stop_inline_style', 9, 'IMPORTANT'))

--- a/tests/test_wrapper_state.py
+++ b/tests/test_wrapper_state.py
@@ -121,6 +121,9 @@ class TestWrapperState(unittest.TestCase):
             'entityRanges': []
         }, '')), '<h1></h1>')
 
+    def test_str(self):
+        self.assertEqual(str(self.wrapper_state), '<WrapperState: []>')
+
 
 class TestBlockquote(unittest.TestCase):
     def test_render(self):

--- a/tests/test_wrapper_state.py
+++ b/tests/test_wrapper_state.py
@@ -101,7 +101,7 @@ class TestWrapperState(unittest.TestCase):
         }, 'Test')), '<blockquote cite="http://example.com/">Test</blockquote>')
 
     def test_element_for_component_wrapper(self):
-        self.wrapper_state.element_for({
+        self.assertEqual(DOM.render(self.wrapper_state.element_for({
             'key': '5s7g9',
             'text': 'Test',
             'type': 'ordered-list-item',
@@ -109,38 +109,17 @@ class TestWrapperState(unittest.TestCase):
             'data': {},
             'inlineStyleRanges': [],
             'entityRanges': []
-        }, 'Test')
-        self.assertEqual(DOM.render(self.wrapper_state.document), '<ol class="list--depth-0"><li class="list-item--depth-0">Test</li></ol>')
-
-    def test_to_string_empty(self):
-        self.assertEqual(self.wrapper_state.to_string(), '')
-
-    def test_to_string_elts(self):
-        self.wrapper_state.element_for({
-            'key': '5s7g9',
-            'text': 'Header',
-            'type': 'header-one',
-            'depth': 0,
-            'inlineStyleRanges': [],
-            'entityRanges': []
-        }, '')
-
-        self.assertEqual(self.wrapper_state.to_string(), '<h1></h1>')
-
-    def test_str_empty(self):
-        self.assertEqual(str(self.wrapper_state), '<WrapperState: >')
+        }, 'Test')), '<ol class="list--depth-0"><li class="list-item--depth-0">Test</li></ol>')
 
     def test_str_elts(self):
-        self.wrapper_state.element_for({
+        self.assertEqual(str(self.wrapper_state.element_for({
             'key': '5s7g9',
             'text': 'Header',
             'type': 'header-one',
             'depth': 0,
             'inlineStyleRanges': [],
             'entityRanges': []
-        }, '')
-
-        self.assertEqual(str(self.wrapper_state), '<WrapperState: <h1></h1>>')
+        }, '')), '<h1></h1>')
 
 
 class TestBlockquote(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,23 +4,19 @@
 # and then run "tox" from this directory.
 
 [tox]
+skipsdist = True
+usedevelop = True
 envlist = py{27,34,35}
 
 [testenv]
 whitelist_externals = make
-install_command = pip install -e ".[testing]" -U {opts} {packages}
+install_command = pip install -e '.[testing]' -U {opts} {packages}
 
 basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
 
-commands = make test
-
-[testenv:py27]
 commands =
     make lint
-    make test
-
-[testenv:py35]
-commands = make test-coverage
+    make test-coverage

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-skipsdist = True
 usedevelop = True
 envlist = py{27,34,35}
 
 [testenv]
 whitelist_externals = make
-install_command = pip install -e '.[testing]' -U {opts} {packages}
+install_command = make init {opts} {packages}
 
 basepython =
     py27: python2.7


### PR DESCRIPTION
Not too big of a speed bump but good to take nonetheless. I would expect real-world content (where text is way more common than entities and styles) to see a higher speed up.

```sh
# Numbers for the perf test suite, and the example (notice how the difference is inverted).
Before: 23420 23688
After: 16631 16344
```