### PR TITLE
Add support for None content state in HTML.render

### DIFF
--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -27,10 +27,13 @@ class HTML:
 
         DOM.use(config.get('engine'))
 
-    def render(self, content_state):
+    def render(self, content_state=None):
         """
         Starts the export process on a given piece of content state.
         """
+        if content_state is None:
+            content_state = {}
+
         wrapper_state = WrapperState(self.block_map)
         document = DOM.create_element()
         entity_map = content_state.get('entityMap', {})

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -287,6 +287,16 @@ class TestHTML(unittest.TestCase):
             ]
         }), '<h1>Header</h1>')
 
+    def test_render_empty(self):
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+            ]
+        }), '')
+
+    def test_render_none(self):
+        self.assertEqual(self.exporter.render(None), '')
+
     def test_render_twice(self):
         """Asserts no state is kept during renders."""
         self.assertEqual(self.exporter.render({


### PR DESCRIPTION
See #60. This will make it easier for us to interface with our new storage of empty fields in Django ORMed DBs.