### PR TITLE
Pre-compile regular expressions used in html5lib and lxml engines

### DIFF
--- a/draftjs_exporter/engines/html5lib.py
+++ b/draftjs_exporter/engines/html5lib.py
@@ -20,8 +20,8 @@ except NameError:
     def unicode(s):
         return str(s)
 
-render_re = re.compile(r'</?(fragment|body|html|head)>')
-render_debug_re = re.compile(r'</?(body|html|head)>')
+RENDER_RE = re.compile(r'</?(fragment|body|html|head)>')
+RENDER_DEBUG_RE = re.compile(r'</?(body|html|head)>')
 
 
 class DOM_HTML5LIB(DOMEngine):
@@ -46,8 +46,8 @@ class DOM_HTML5LIB(DOMEngine):
 
     @staticmethod
     def render(elt):
-        return render_re.sub('', unicode(elt))
+        return RENDER_RE.sub('', unicode(elt))
 
     @staticmethod
     def render_debug(elt):
-        return render_debug_re.sub('', unicode(elt))
+        return RENDER_DEBUG_RE.sub('', unicode(elt))

--- a/draftjs_exporter/engines/html5lib.py
+++ b/draftjs_exporter/engines/html5lib.py
@@ -20,6 +20,9 @@ except NameError:
     def unicode(s):
         return str(s)
 
+render_re = re.compile(r'</?(fragment|body|html|head)>')
+render_debug_re = re.compile(r'</?(body|html|head)>')
+
 
 class DOM_HTML5LIB(DOMEngine):
     """
@@ -43,8 +46,8 @@ class DOM_HTML5LIB(DOMEngine):
 
     @staticmethod
     def render(elt):
-        return re.sub(r'</?(fragment|body|html|head)>', '', unicode(elt))
+        return render_re.sub('', unicode(elt))
 
     @staticmethod
     def render_debug(elt):
-        return re.sub(r'</?(body|html|head)>', '', unicode(elt))
+        return render_debug_re.sub('', unicode(elt))

--- a/draftjs_exporter/engines/lxml.py
+++ b/draftjs_exporter/engines/lxml.py
@@ -13,6 +13,8 @@ NSMAP = {
     'xlink': 'http://www.w3.org/1999/xlink',
 }
 
+render_re = re.compile(r'</?fragment>')
+
 
 class DOM_LXML(DOMEngine):
     """
@@ -44,7 +46,7 @@ class DOM_LXML(DOMEngine):
 
     @staticmethod
     def render(elt):
-        return re.sub(r'</?fragment>', '', etree.tostring(elt, method='html', encoding='unicode'))
+        return render_re.sub('', etree.tostring(elt, method='html', encoding='unicode'))
 
     @staticmethod
     def render_debug(elt):

--- a/draftjs_exporter/engines/lxml.py
+++ b/draftjs_exporter/engines/lxml.py
@@ -13,7 +13,7 @@ NSMAP = {
     'xlink': 'http://www.w3.org/1999/xlink',
 }
 
-render_re = re.compile(r'</?fragment>')
+RENDER_RE = re.compile(r'</?fragment>')
 
 
 class DOM_LXML(DOMEngine):
@@ -46,7 +46,7 @@ class DOM_LXML(DOMEngine):
 
     @staticmethod
     def render(elt):
-        return render_re.sub('', etree.tostring(elt, method='html', encoding='unicode'))
+        return RENDER_RE.sub('', etree.tostring(elt, method='html', encoding='unicode'))
 
     @staticmethod
     def render_debug(elt):


### PR DESCRIPTION
Thanks to @BertrandBordage for the suggestion.

This is quite a straightforward performance improvement. The speedup isn't big, but the change is very simple so well worth it.

