### PR TITLE
Fix string engine incorrectly skipping identical elements at the same depth level

### DIFF
--- a/draftjs_exporter/engines/string.py
+++ b/draftjs_exporter/engines/string.py
@@ -33,11 +33,20 @@ VOID_ELEMENTS = {
 
 
 class Elt(object):
-    def __init__(self, type_, attr, children, markup):
+    """
+    An DOM element that the string engine manipulates.
+    This class doesn't do much, but the exporter relies on
+    comparing elements by reference so it's useful nonetheless.
+    """
+    def __init__(self, type_, attr, markup=None):
         self.type = type_
         self.attr = attr
-        self.children = children
+        self.children = []
         self.markup = markup
+
+    @staticmethod
+    def from_html(markup):
+        return Elt('escaped_html', None, markup)
 
 
 class DOMString(DOMEngine):
@@ -47,7 +56,7 @@ class DOMString(DOMEngine):
 
     @staticmethod
     def create_tag(type_, attr=None):
-        return Elt(type_, attr, [], None)
+        return Elt(type_, attr)
 
     @staticmethod
     def parse_html(markup):
@@ -55,7 +64,7 @@ class DOMString(DOMEngine):
         Allows inserting arbitrary HTML into the exporter output.
         Treats the HTML as if it had been escaped and was safe already.
         """
-        return Elt('escaped_html', None, None, markup)
+        return Elt.from_html(markup)
 
     @staticmethod
     def append_child(elt, child):

--- a/tests/engines/test_engines_string.py
+++ b/tests/engines/test_engines_string.py
@@ -21,6 +21,18 @@ class TestDOMString(unittest.TestCase):
         DOMString.append_child(parent, DOMString.create_tag('span', {}))
         self.assertEqual(DOMString.render_debug(parent), '<p><span></span></p>')
 
+    def test_append_child_identical_text(self):
+        parent = DOMString.create_tag('p')
+        DOMString.append_child(parent, 'test')
+        DOMString.append_child(parent, 'test')
+        self.assertEqual(DOMString.render_debug(parent), '<p>testtest</p>')
+
+    def test_append_child_identical_elements(self):
+        parent = DOMString.create_tag('p')
+        DOMString.append_child(parent, DOMString.create_tag('br'))
+        DOMString.append_child(parent, DOMString.create_tag('br'))
+        self.assertEqual(DOMString.render_debug(parent), '<p><br/><br/></p>')
+
     def test_render_attrs(self):
         self.assertEqual(DOMString.render_attrs({
             'src': 'src.png',

--- a/tests/test_exports.json
+++ b/tests/test_exports.json
@@ -1000,5 +1000,35 @@
                 "data": {}
             }]
         }
+    },
+
+    {
+        "label": "Same content multiple times",
+        "output": {
+            "html5lib": "<p>a</p><p>a</p>",
+            "lxml": "<p>a</p><p>a</p>",
+            "string": "<p>a</p><p>a</p>"
+        },
+        "content_state": {
+            "entityMap": {},
+            "blocks": [
+                {
+                    "key": "99n0j",
+                    "text": "a",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": []
+                },
+                {
+                    "key": "19n0j",
+                    "text": "a",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": []
+                }
+            ]
+        }
     }
 ]


### PR DESCRIPTION
Interestingly, there was no test for _that_! I've added some. This bug is easily reproducible on http://draftjs-exporter.herokuapp.com/:

<img width="1243" alt="string-engine-same-elements" src="https://user-images.githubusercontent.com/877585/33683956-46dab120-dad5-11e7-95d2-265ffde4476f.png">

The problem is that the `append_child` method checks if elements are already present by value rather than by reference, so if two elements have equal values (same type, same children, same   attributes) the subsequent ones will be skipped.

I initially changed the check so it would be by reference (`any(c is child for c in elt['children'])`), but that's ± 5% slower in the benchmark so instead I converted the dicts into class instances so the `in` operator looks at references.