### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,8 +28,9 @@ pyenv install --skip-existing 2.7.11
 pyenv install --skip-existing 3.4.4
 pyenv install --skip-existing 3.5.1
 pyenv install --skip-existing 3.6.3
+pyenv install --skip-existing 3.7.0
 # Make required Python versions available globally.
-pyenv global system 2.7.11 3.4.4 3.5.1 3.6.3
+pyenv global system 2.7.11 3.4.4 3.5.1 3.6.3 3.7.0
 ```
 
 ### Commands

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
   - env: TOXENV=py36-lower_bound_deps
     python: 3.6
   - env: TOXENV=py37-lower_bound_deps
-    python: 3.7-dev
+    python: 3.7
+    sudo: required
+    dist: xenial
   - env: TOXENV=py27-upper_bound_deps
     python: 2.7
   - env: TOXENV=py34-upper_bound_deps
@@ -22,7 +24,9 @@ matrix:
   - env: TOXENV=py36-upper_bound_deps
     python: 3.6
   - env: TOXENV=py37-upper_bound_deps
-    python: 3.7-dev
+    python: 3.7
+    sudo: required
+    dist: xenial
 install:
 - pip install tox coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     python: 3.5
   - env: TOXENV=py36-lower_bound_deps
     python: 3.6
+  - env: TOXENV=py37-lower_bound_deps
+    python: 3.7-dev
   - env: TOXENV=py27-upper_bound_deps
     python: 2.7
   - env: TOXENV=py34-upper_bound_deps
@@ -19,6 +21,8 @@ matrix:
     python: 3.5
   - env: TOXENV=py36-upper_bound_deps
     python: 3.6
+  - env: TOXENV=py37-upper_bound_deps
+    python: 3.7-dev
 install:
 - pip install tox coveralls
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ### Changed
 
-* Add upper bound to lxml dependency, now defined as `lxml>=3.6.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
+* Increase lower bound of lxml dependency to v4.2.0 to guarantee Python 3.7 support ([#88](https://github.com/springload/draftjs_exporter/pull/88)).
+* Add upper bound to lxml dependency, now defined as `lxml>=4.2.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
 * Update html5lib upper bound, now defined as `html5lib>=0.999,<=1.0.1`.
 
 ## [v2.1.0](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.0)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Internet :: WWW/HTTP :: Site Management',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 dependencies = {
     # Keep this in sync with the dependencies in tox.ini.
     'lxml': [
-        'lxml>=3.6.0,<5',
+        'lxml>=4.2.0,<5',
     ],
     'html5lib': [
         'beautifulsoup4>=4.4.1,<5',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 usedevelop = True
-envlist = py{27,34,35,36}-{lower_bound_deps,upper_bound_deps}
+envlist = py{27,34,35,36,37}-{lower_bound_deps,upper_bound_deps}
 
 [testenv]
 whitelist_externals = make
@@ -16,6 +16,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 deps =
     # Keep this in sync with the dependencies in setup.py.

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     # Keep this in sync with the dependencies in setup.py.
     lower_bound_deps: beautifulsoup4==4.4.1
     lower_bound_deps: html5lib==0.999
-    lower_bound_deps: lxml==3.6.0
+    lower_bound_deps: lxml==4.2.0
     upper_bound_deps: beautifulsoup4<5
     upper_bound_deps: html5lib<=1.0.1
     upper_bound_deps: lxml<5


### PR DESCRIPTION
This is just adding the version to the CI test matrix after trying it locally.

It seems to work fine on my computer (Python 3.7.0-a1, macOS 10.13, lxml 4.1.1), but it fails in CI (Python 3.7.0a4+, Ubuntu Trusty, lxml 4.1.1) because of one "differences between engines" test:

```
    self.assertEqual(DOM_LXML.render_debug(DOM_LXML.parse_html('<p>Invalid < " > &</p>')), '<p>Invalid &lt; " &gt; &amp;</p>')
AssertionError: '<p>Invalid  &amp;</p>' != '<p>Invalid &lt; " &gt; &amp;</p>'
- <p>Invalid  &amp;</p>
+ <p>Invalid &lt; " &gt; &amp;</p>
```

That’s only lxml code here (`html.fromstring`), so it's either an issue there or in Python 3.7. I'll wait for the beta / RC release to be available on pyenv and in Travis before pursuing this further.

---

I just noticed the recent [3.7.0-b1 release](https://www.python.org/downloads/release/python-370b1/), and thought now would be a good time to try this.

Here are some dates from that article:

> Start of the release candidate phase: 2018-05-21
> The official release of 3.7.0 is planned for 2018-06-15.

FYI here is the fragmentation in Python versions for installers of this package via pip over the last 30 days:

```
$ pypinfo --pip draftjs_exporter pyversion
python_version download_count
-------------- --------------
3.6                       240
3.5                       156
2.7                       100
3.4                        69
```