### PR TITLE
Improve performance by bypassing costly style/entity processing for text-only blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Changed
+
+* Performance improvements for text-only (no inline styles, no entities) blocks.
+
 ## [v2.0.0](https://github.com/springload/draftjs_exporter/releases/tag/v2.0.0)
 
 This release contains breaking changes that will require updating the exporter's configurations. **Be sure to check out the "how to upgrade" section below.**


### PR DESCRIPTION
Style & entity ranges processing (conversion from potentially overlapping ranges to nested styles) is one of the most complicated parts of the exporter. Bypassing it completely for blocks that do not contain styles nor entities greatly improves the performance for real-world content, which is mostly text-only.

As an example, [our real-world benchmark content](https://github.com/thibaudcolas/markov_draftjs) has 5650 blocks, 204 of which have styles, and 942 of which have entities (with some potential overlap). Even with no overlap, it means 80% of the content will benefit from this change.

----

## Numbers before/after

`make dev` demo:

```sh
# Before
7074 function calls (6745 primitive calls)
# After
6207 function calls (5878 primitive calls)
```

`make benchmark`:

```sh
# Before
801431 function calls (757891 primitive calls) in 0.563 seconds
0.148438 MiB
# After
593879 function calls (550339 primitive calls) in 0.416 seconds
0.085938 MiB
```

That's about a 25% speed bump and 2x smaller memory consumption.

<details>

<summary>Full results</summary>

### `make benchmark` before

```
python benchmark.py
Exporting 792 ContentStates 1 times
         801431 function calls (757891 primitive calls) in 0.563 seconds

   Ordered by: cumulative time
   List reduced from 81 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      792    0.013    0.000    0.563    0.001 html.py:30(render)
     5650    0.066    0.000    0.436    0.000 html.py:59(render_block)
     5650    0.018    0.000    0.119    0.000 wrapper_state.py:89(element_for)
     5650    0.041    0.000    0.104    0.000 html.py:85(build_command_groups)
      792    0.001    0.000    0.102    0.000 dom.py:118(render)
14924/792    0.019    0.000    0.101    0.000 string.py:86(render)
14914/792    0.012    0.000    0.101    0.000 string.py:82(render_children)
14914/792    0.018    0.000    0.099    0.000 string.py:84(<listcomp>)
18026/16862    0.039    0.000    0.085    0.000 dom.py:44(create_element)
    29668    0.013    0.000    0.045    0.000 dom.py:114(append_child)


Measuring memory consumption
Filename: benchmark.py

Line #    Mem usage    Increment   Line Contents
================================================
    98  40.750000 MiB   0.000000 MiB   @profile(precision=6)
    99                             def memory_consumption_run():
   100  40.750000 MiB   0.000000 MiB       exporter = HTML(config)
   101
   102  40.898438 MiB   0.148438 MiB       for content_state in content_states:
   103  40.898438 MiB   0.000000 MiB           exporter.render(content_state)
```

### `make benchmark` after

```
python benchmark.py
Exporting 792 ContentStates 1 times
         593879 function calls (550339 primitive calls) in 0.416 seconds

   Ordered by: cumulative time
   List reduced from 81 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      792    0.011    0.000    0.416    0.001 html.py:30(render)
     5650    0.035    0.000    0.304    0.000 html.py:59(render_block)
     5650    0.017    0.000    0.117    0.000 wrapper_state.py:89(element_for)
      792    0.001    0.000    0.089    0.000 dom.py:118(render)
14924/792    0.019    0.000    0.089    0.000 string.py:86(render)
14914/792    0.012    0.000    0.088    0.000 string.py:82(render_children)
14914/792    0.016    0.000    0.086    0.000 string.py:84(<listcomp>)
18026/16862    0.038    0.000    0.082    0.000 dom.py:44(create_element)
     6507    0.012    0.000    0.044    0.000 composite_decorators.py:46(render_decorators)
    25156    0.011    0.000    0.039    0.000 dom.py:114(append_child)


Measuring memory consumption
Filename: benchmark.py

Line #    Mem usage    Increment   Line Contents
================================================
    98  40.621094 MiB   0.000000 MiB   @profile(precision=6)
    99                             def memory_consumption_run():
   100  40.621094 MiB   0.000000 MiB       exporter = HTML(config)
   101
   102  40.707031 MiB   0.085938 MiB       for content_state in content_states:
   103  40.707031 MiB   0.000000 MiB           exporter.render(content_state)
```

</details>

---

Edit: this is best reviewed with [`?w=1`](https://github.com/springload/draftjs_exporter/pull/89/files?w=1).