### PR TITLE
Improve dependencies compatibility definition, and testing. Fix #75

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,22 @@ language: python
 cache: pip
 matrix:
   include:
-   - env: TOXENV=py27
-     python: 2.7
-   - env: TOXENV=py34
-     python: 3.4
-   - env: TOXENV=py35
-     python: 3.5
-   - env: TOXENV=py36
-     python: 3.6
+  - env: TOXENV=py27-lower_bound_deps
+    python: 2.7
+  - env: TOXENV=py34-lower_bound_deps
+    python: 3.4
+  - env: TOXENV=py35-lower_bound_deps
+    python: 3.5
+  - env: TOXENV=py36-lower_bound_deps
+    python: 3.6
+  - env: TOXENV=py27-upper_bound_deps
+    python: 2.7
+  - env: TOXENV=py34-upper_bound_deps
+    python: 3.4
+  - env: TOXENV=py35-upper_bound_deps
+    python: 3.5
+  - env: TOXENV=py36-upper_bound_deps
+    python: 3.6
 install:
 - pip install tox coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 cache: pip
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 * Add upper bound to lxml dependency, now defined as `lxml>=3.6.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
+* Update html5lib upper bound, now defined as `html5lib>=0.999,<=1.0.1`.
 
 ## [v2.1.0](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Changed
+
+* Add upper bound to lxml dependency, now defined as `lxml>=3.6.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
+
 ## [v2.1.0](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ make init
 pyenv install --skip-existing 2.7.11
 pyenv install --skip-existing 3.4.4
 pyenv install --skip-existing 3.5.1
+pyenv install --skip-existing 3.6.3
 # Make required Python versions available globally.
-pyenv global system 2.7.11 3.4.4 3.5.1
+pyenv global system 2.7.11 3.4.4 3.5.1 3.6.3
 ```
 
 ### Commands

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,9 +91,9 @@ Python versions as defined in `setup.py` classifiers.
 
 #### Which version combinations to include in Travis test matrix?
 
-All supported Python version should be tested.
+All supported Python versions should be tested.
 
-At the moment, tests are only ran against the latest version of BeautifulSoup `4.x` and the latest version of LXML.
+Each version should be tested with the lower and upper bounds of supported version ranges for all dependencies.
 
 ## Troubleshooting
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dependencies = []
 
 html5lib_dependencies = [
     'beautifulsoup4>=4.4.1,<5',
-    'html5lib>=0.999,<=1.0b10',
+    'html5lib>=0.999,<=1.0.1',
 ]
 
 lxml_dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ html5lib_dependencies = [
 ]
 
 lxml_dependencies = [
-    'lxml>=3.6.0',
+    'lxml>=3.6.0,<5',
 ]
 
 testing_dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -12,18 +12,20 @@ try:
 except ImportError:
     from distutils.core import setup
 
-dependencies = []
+dependencies = {
+    # Keep this in sync with the dependencies in tox.ini.
+    'lxml': [
+        'lxml>=3.6.0,<5',
+    ],
+    'html5lib': [
+        'beautifulsoup4>=4.4.1,<5',
+        'html5lib>=0.999,<=1.0.1',
+    ],
+    'docs': [],
+}
 
-html5lib_dependencies = [
-    'beautifulsoup4>=4.4.1,<5',
-    'html5lib>=0.999,<=1.0.1',
-]
-
-lxml_dependencies = [
-    'lxml>=3.6.0,<5',
-]
-
-testing_dependencies = [
+# Development extras.
+dependencies['testing'] = [
     # Required for running the tests.
     'tox>=2.3.1',
 
@@ -36,11 +38,7 @@ testing_dependencies = [
     'coverage>=4.1.0',
     'flake8>=3.2.0',
     'isort==4.2.5',
-] + html5lib_dependencies + lxml_dependencies
-
-documentation_dependencies = [
-
-]
+] + dependencies['html5lib'] + dependencies['lxml']
 
 RE_MD_CODE_BLOCK = re.compile(
     r'```(?P<language>\w+)?\n(?P<lines>.*?)```', re.S)
@@ -114,13 +112,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Editors :: Word Processors',
     ],
-    install_requires=dependencies,
-    extras_require={
-        # Special extra installs for the built-in DOM engines.
-        'lxml': lxml_dependencies,
-        'html5lib': html5lib_dependencies,
-        # Development extras.
-        'testing': testing_dependencies,
-        'docs': documentation_dependencies,
-    },
-    zip_safe=False)
+    install_requires=[],
+    extras_require=dependencies,
+    zip_safe=False,
+)

--- a/tests/engines/test_engines_differences.py
+++ b/tests/engines/test_engines_differences.py
@@ -59,10 +59,10 @@ class TestDOMEnginesDifferences(unittest.TestCase):
         })), '<img alt="&lt; &quot; &#x27; &lt; &gt; &amp;"/>')
 
     def test_html5lib_html_parsing(self):
-        self.assertEqual(DOM_HTML5LIB.render_debug(DOM_HTML5LIB.parse_html('<p>Invalid < " > &</p>')), '<p>Invalid &lt; " &gt; &amp;</p>')
+        self.assertEqual(DOM_HTML5LIB.render_debug(DOM_HTML5LIB.parse_html('<p>Invalid > " &</p>')), '<p>Invalid &gt; " &amp;</p>')
 
     def test_lxml_html_parsing(self):
-        self.assertEqual(DOM_LXML.render_debug(DOM_LXML.parse_html('<p>Invalid < " > &</p>')), '<p>Invalid &lt; " &gt; &amp;</p>')
+        self.assertEqual(DOM_LXML.render_debug(DOM_LXML.parse_html('<p>Invalid > " &</p>')), '<p>Invalid &gt; " &amp;</p>')
 
     def test_string_html_parsing(self):
-        self.assertEqual(DOMString.render_debug(DOMString.parse_html('<p>Invalid < " > &</p>')), '<p>Invalid < " > &</p>')
+        self.assertEqual(DOMString.render_debug(DOMString.parse_html('<p>Invalid > " &</p>')), '<p>Invalid > " &</p>')

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 usedevelop = True
-envlist = py{27,34,35,36}
+envlist = py{27,34,35,36}-{lower_bound_deps,upper_bound_deps},
 
 [testenv]
 whitelist_externals = make
@@ -16,6 +16,14 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+
+deps =
+    lower_bound_deps: beautifulsoup4==4.4.1
+    lower_bound_deps: html5lib==0.999
+    lower_bound_deps: lxml==3.6.0
+    upper_bound_deps: beautifulsoup4<5
+    upper_bound_deps: html5lib<=1.0b10
+    upper_bound_deps: lxml<5
 
 commands =
     make lint

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     lower_bound_deps: html5lib==0.999
     lower_bound_deps: lxml==3.6.0
     upper_bound_deps: beautifulsoup4<5
-    upper_bound_deps: html5lib<=1.0b10
+    upper_bound_deps: html5lib<=1.0.1
     upper_bound_deps: lxml<5
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 usedevelop = True
-envlist = py{27,34,35,36}-{lower_bound_deps,upper_bound_deps},
+envlist = py{27,34,35,36}-{lower_bound_deps,upper_bound_deps}
 
 [testenv]
 whitelist_externals = make
@@ -18,6 +18,7 @@ basepython =
     py36: python3.6
 
 deps =
+    # Keep this in sync with the dependencies in setup.py.
     lower_bound_deps: beautifulsoup4==4.4.1
     lower_bound_deps: html5lib==0.999
     lower_bound_deps: lxml==3.6.0


### PR DESCRIPTION
Fixes #75.

The only user-facing changes are:

- The new upper version bound for lxml, which wasn't defined before.
- The new upper version bound for html5lib, which used to be lower (now that htm5lib has been released with good version numbers).

This PR also updates the tox environments, as described in #75.