### PR TITLE
Release v2.1.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,3 +7,64 @@ We welcome all support, whether on bug reports, code, design, reviews, tests, do
 Please note that this project is released with a [Contributor Code of Conduct](docs/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 [![Code Climate for draftjs_exporter](https://codeclimate.com/github/springload/draftjs_exporter/badges/gpa.svg)](https://codeclimate.com/github/springload/draftjs_exporter)
+
+## Development
+
+### Installation
+
+> Requirements: `virtualenv`, `pyenv`, `twine`
+
+```sh
+git clone git@github.com:springload/draftjs_exporter.git
+cd draftjs_exporter/
+# Install the git hooks.
+./.githooks/deploy
+# Install the Python environment.
+virtualenv .venv
+source ./.venv/bin/activate
+make init
+# Install required Python versions
+pyenv install --skip-existing 2.7.11
+pyenv install --skip-existing 3.4.4
+pyenv install --skip-existing 3.5.1
+pyenv install --skip-existing 3.6.3
+# Make required Python versions available globally.
+pyenv global system 2.7.11 3.4.4 3.5.1 3.6.3
+```
+
+### Commands
+
+```sh
+make help            # See what commands are available.
+make init            # Install dependencies and initialise for development.
+make lint            # Lint the project.
+make test            # Test the project.
+make test-watch      # Restarts the tests whenever a file changes.
+make test-coverage   # Run the tests while generating test coverage data.
+make test-ci         # Continuous integration test suite.
+make dev             # Restarts the example whenever a file changes.
+make benchmark       # Runs a one-off performance (speed, memory) benchmark.
+make clean-pyc       # Remove Python file artifacts.
+make publish         # Publishes a new version to pypi.
+```
+
+### Debugging
+
+* Always run the tests. `npm install -g nodemon`, then `make test-watch`.
+* Use a debugger. `pip install ipdb`, then `import ipdb; ipdb.set_trace()`.
+
+### Releases
+
+* Make a new branch for the release of the new version.
+* Update the [CHANGELOG](https://github.com/springload/draftjs_exporter/CHANGELOG.md).
+* Update the version number in `draftjs_exporter/__init__.py`, following semver.
+* Make a PR and squash merge it.
+* Back on master with the PR merged, use `make publish` (confirm, and enter your password).
+* Finally, go to GitHub and create a release and a tag for the new version.
+* Done!
+
+> As a last step, you may want to go update our [Draft.js exporter demo](https://github.com/springload/draftjs_exporter_demo) to this new release to check that all is well in a fully separate project.
+
+## Documentation
+
+> See the [docs](https://github.com/springload/draftjs_exporter/tree/master/docs) folder.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please note that this project is released with a [Contributor Code of Conduct](d
 
 ### Installation
 
-> Requirements: `virtualenv`, `pyenv`, `twine`
+> Requirements: `virtualenv`, `pyenv`
 
 ```sh
 git clone git@github.com:springload/draftjs_exporter.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+## [v2.1.1](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.1)
+
 ### Changed
 
 * Add upper bound to lxml dependency, now defined as `lxml>=3.6.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## See what commands are available.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36mmake %-15s\033[0m # %s\n", $$1, $$2}'
 
 init: clean-pyc ## Install dependencies and initialise for development.
-	pip install --upgrade pip
+	pip install --upgrade pip setuptools twine
 	pip install -e '.[testing,docs]' -U
 
 lint: ## Lint the project.

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,4 @@ clean-pyc: ## Remove Python file artifacts.
 	find . -name '*~' -exec rm -f {} +
 
 publish: ## Publishes a new version to pypi.
-	rm dist/* && python setup.py sdist && twine upload dist/* && echo 'Success! Go to https://pypi.python.org/pypi/draftjs_exporter and check that all is well.'
+	rm dist/* && python setup.py sdist && twine upload dist/* && echo 'Success! Go to https://pypi.org/project/draftjs_exporter/ and check that all is well.'

--- a/README.md
+++ b/README.md
@@ -292,66 +292,11 @@ exporter = HTML({
 })
 ```
 
-## Development
+## Contributing
 
-### Installation
+See anything you like in here? Anything missing? We welcome all support, whether on bug reports, feature requests, code, design, reviews, tests, documentation, and more. Please have a look at our [contribution guidelines](.github/CONTRIBUTING.md).
 
-> Requirements: `virtualenv`, `pyenv`, `twine`
-
-```sh
-git clone git@github.com:springload/draftjs_exporter.git
-cd draftjs_exporter/
-# Install the git hooks.
-./.githooks/deploy
-# Install the Python environment.
-virtualenv .venv
-source ./.venv/bin/activate
-make init
-# Install required Python versions
-pyenv install --skip-existing 2.7.11
-pyenv install --skip-existing 3.4.4
-pyenv install --skip-existing 3.5.1
-pyenv install --skip-existing 3.6.3
-# Make required Python versions available globally.
-pyenv global system 2.7.11 3.4.4 3.5.1 3.6.3
-```
-
-### Commands
-
-```sh
-make help            # See what commands are available.
-make init            # Install dependencies and initialise for development.
-make lint            # Lint the project.
-make test            # Test the project.
-make test-watch      # Restarts the tests whenever a file changes.
-make test-coverage   # Run the tests while generating test coverage data.
-make test-ci         # Continuous integration test suite.
-make dev             # Restarts the example whenever a file changes.
-make benchmark       # Runs a one-off performance (speed, memory) benchmark.
-make clean-pyc       # Remove Python file artifacts.
-make publish         # Publishes a new version to pypi.
-```
-
-### Debugging
-
-* Always run the tests. `npm install -g nodemon`, then `make test-watch`.
-* Use a debugger. `pip install ipdb`, then `import ipdb; ipdb.set_trace()`.
-
-### Releases
-
-* Make a new branch for the release of the new version.
-* Update the [CHANGELOG](https://github.com/springload/draftjs_exporter/CHANGELOG.md).
-* Update the version number in `draftjs_exporter/__init__.py`, following semver.
-* Make a PR and squash merge it.
-* Back on master with the PR merged, use `make publish` (confirm, and enter your password).
-* Finally, go to GitHub and create a release and a tag for the new version.
-* Done!
-
-> As a last step, you may want to go update our [Draft.js exporter demo](https://github.com/springload/draftjs_exporter_demo) to this new release to check that all is well in a fully separate project.
-
-## Documentation
-
-> See the [docs](https://github.com/springload/draftjs_exporter/tree/master/docs) folder.
+If you just want to set up the project on your own computer, the contribution guidelines also contain all of the setup commands.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 > Library to convert rich text from Draft.js raw ContentState to HTML.
 
-It is developed alongside the [Draftail](https://github.com/springload/draftail/) rich text editor, for [Wagtail](https://wagtail.io/). Check out the [online demo](https://draftjs-exporter.herokuapp.com/), and our [introductory blog post](https://wagtail.io/blog/rethinking-rich-text-pipelines-with-draft-js/)
+It is developed alongside the [Draftail](https://github.com/springload/draftail/) rich text editor, for [Wagtail](https://github.com/wagtail/wagtail). Check out the [online demo](https://draftail-playground.herokuapp.com/), and our [introductory blog post](https://wagtail.io/blog/rethinking-rich-text-pipelines-with-draft-js/)
 
 ## Why
 
 [Draft.js](https://draftjs.org/) is a rich text editor framework for React. Its approach is different from most rich text editors because it does not store data as HTML, but rather in its own representation called ContentState. This exporter is useful when the ContentState to HTML conversion has to be done in a Python ecosystem.
 
-The initial use case was to gain more control over the content managed by rich text editors in a Wagtail/Django site, as part of our [WagtailDraftail](https://github.com/springload/wagtaildraftail) project.
-
-If you want to read the full story, have a look at our blog post: [Rethinking rich text pipelines with Draft.js](https://wagtail.io/blog/rethinking-rich-text-pipelines-with-draft-js/).
+The initial use case was to gain more control over the content managed by rich text editors in a Wagtail/Django site. If you want to read the full story, have a look at our blog post: [Rethinking rich text pipelines with Draft.js](https://wagtail.io/blog/rethinking-rich-text-pipelines-with-draft-js/).
 
 ## Features
 
@@ -70,7 +68,7 @@ html = exporter.render({
 print(html)
 ```
 
-You can also run an example by downloading this repository and then using `python example.py`, or by using our [online demo](https://draftjs-exporter.herokuapp.com/).
+You can also run an example by downloading this repository and then using `python example.py`, or by using our [online demo](https://draftail-playground.herokuapp.com/).
 
 ### Configuration
 
@@ -302,4 +300,4 @@ If you just want to set up the project on your own computer, the contribution gu
 
 This project is made possible by the work of [Springload](https://github.com/springload), a New Zealand digital agency, and. The _beautiful_ demo site is the work of [@thibaudcolas](https://github.com/thibaudcolas).
 
-View the full list of [contributors](https://github.com/springload/draftail/graphs/contributors). [MIT](https://github.com/springload/draftjs_exporter/blob/master/LICENSE) licensed.
+View the full list of [contributors](https://github.com/springload/draftjs_exporter/graphs/contributors). [MIT](https://github.com/springload/draftjs_exporter/blob/master/LICENSE) licensed.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Draft.js exporter [![PyPI](https://img.shields.io/pypi/v/draftjs_exporter.svg)](https://pypi.python.org/pypi/draftjs_exporter) [![Travis](https://travis-ci.org/springload/draftjs_exporter.svg?branch=master)](https://travis-ci.org/springload/draftjs_exporter) [![Coveralls](https://coveralls.io/repos/github/springload/draftjs_exporter/badge.svg?branch=master)](https://coveralls.io/github/springload/draftjs_exporter?branch=master)
+# Draft.js exporter [![PyPI](https://img.shields.io/pypi/v/draftjs_exporter.svg)](https://pypi.org/project/draftjs_exporter/) [![Travis](https://travis-ci.org/springload/draftjs_exporter.svg?branch=master)](https://travis-ci.org/springload/draftjs_exporter) [![Coveralls](https://coveralls.io/repos/github/springload/draftjs_exporter/badge.svg?branch=master)](https://coveralls.io/github/springload/draftjs_exporter?branch=master)
 
 > Library to convert rich text from Draft.js raw ContentState to HTML.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,4 @@
-draftjs_exporter documentation
-==============================
+# Documentation
 
 > This project started as a Python port of the [draftjs_exporter](https://github.com/ignitionworks/draftjs_exporter) ruby library.
 
@@ -99,12 +98,12 @@ Each version should be tested with the lower and upper bounds of supported versi
 
 ### Install
 
-```
-$ pip install draftjs_exporter
-[...]
-*********************************************************************************
-Could not find function xmlCheckVersion in library libxml2. Is libxml2 installed?
-*********************************************************************************
+```sh
+pip install draftjs_exporter
+# [...]
+# *********************************************************************************
+# Could not find function xmlCheckVersion in library libxml2. Is libxml2 installed?
+#*********************************************************************************
 ```
 
 Solution: see http://stackoverflow.com/a/6504860/1798491

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'draftjs_exporter'
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 __author__ = 'Springload'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016-present Springload'

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,9 @@
 
 from __future__ import absolute_import, unicode_literals
 
-import io
-import re
-
 from draftjs_exporter import __version__
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup
+from setuptools import find_packages, setup
 
 dependencies = {
     # Keep this in sync with the dependencies in tox.ini.
@@ -40,53 +34,15 @@ dependencies['testing'] = [
     'isort==4.2.5',
 ] + dependencies['html5lib'] + dependencies['lxml']
 
-RE_MD_CODE_BLOCK = re.compile(
-    r'```(?P<language>\w+)?\n(?P<lines>.*?)```', re.S)
-RE_LINK = re.compile(r'\[(?P<text>.*?)\]\((?P<url>.*?)\)')
-RE_IMAGE = re.compile(r'\!\[(?P<text>.*?)\]\((?P<url>.*?)\)')
-RE_TITLE = re.compile(r'^(?P<level>#+)\s*(?P<title>.*)$', re.M)
-RE_CODE = re.compile(r'``([^<>]*?)``')
-
-RST_TITLE_LEVELS = ['=', '-', '~']
-
-
-def md2pypi(filename):
-    '''
-    Load .md (markdown) file and sanitize it for PyPI.
-    '''
-    content = io.open(filename).read()
-
-    for match in RE_MD_CODE_BLOCK.finditer(content):
-        rst_block = '\n'.join(
-            ['.. code-block:: {language}'.format(**match.groupdict()), ''] +
-            ['    {0}'.format(l) for l in match.group('lines').split('\n')] +
-            ['']
-        )
-        content = content.replace(match.group(0), rst_block)
-
-    for match in RE_IMAGE.finditer(content):
-        content = content.replace(match.group(0), match.group(1))
-
-    content = RE_LINK.sub('`\g<text> <\g<url>>`_', content)
-    content = RE_CODE.sub('``\g<1>``', content)
-
-    for match in RE_TITLE.finditer(content):
-        level = len(match.group('level')) - 1
-        underchar = RST_TITLE_LEVELS[level]
-        title = match.group('title')
-        underline = underchar * len(title)
-
-        full_title = '\n'.join((title, underline))
-        content = content.replace(match.group(0), full_title)
-
-    return content
-
+with open('README.md') as f:
+    long_description = f.read()
 
 setup(
     name='draftjs_exporter',
     version=__version__,
     description='Library to convert rich text from Draft.js raw ContentState to HTML',
-    long_description=md2pypi('README.md'),
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Springload',
     author_email='hello@springload.co.nz',
     url='https://github.com/springload/draftjs_exporter',


### PR DESCRIPTION
Changelog: 

 * Add upper bound to lxml dependency, now defined as `lxml>=3.6.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
 * Update html5lib upper bound, now defined as `html5lib>=0.999,<=1.0.1`.

This also introduces a proper Markdown description for the PyPI project's page 🎉(https://github.com/wagtail/wagtail/pull/4372#discussion_r177637239).