### PR TITLE
Use io.open with utf-8 encoding in setup.py. Fix #98

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import io
+
 from draftjs_exporter import __version__
 
 from setuptools import find_packages, setup
@@ -34,8 +36,7 @@ dependencies['testing'] = [
     'isort==4.2.5',
 ] + dependencies['html5lib'] + dependencies['lxml']
 
-with open('README.md') as f:
-    long_description = f.read()
+long_description = io.open('README.md', encoding='utf-8').read()
 
 setup(
     name='draftjs_exporter',


### PR DESCRIPTION
Should fix #98. `io.open` is available in both Python 2.7 and 3, and as an `encoding` option.