### PR TITLE
Release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## [v2.1.2](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.2)
+
+### Changed
+
+*  Use io.open with utf-8 encoding in setup.py. Fix [#98](https://github.com/springload/draftjs_exporter/issues/98) ([#99](https://github.com/springload/draftjs_exporter/pull/99))
+
 ## [v2.1.1](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.1)
 
 ### Changed

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'draftjs_exporter'
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 __author__ = 'Springload'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016-present Springload'


### PR DESCRIPTION
*  Use io.open with utf-8 encoding in setup.py. Fix [#98](https://github.com/springload/draftjs_exporter/issues/98) ([#99](https://github.com/springload/draftjs_exporter/pull/99))