### PR TITLE
Release v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## [v2.1.3](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.3)
+
+### Changed
+
+* Increase lower bound of optional lxml dependency to v4.2.0 to guarantee Python 3.7 support ([#88](https://github.com/springload/draftjs_exporter/pull/88)).
+
 ## [v2.1.2](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.2)
 
 ### Changed
@@ -14,8 +20,7 @@
 
 ### Changed
 
-* Increase lower bound of lxml dependency to v4.2.0 to guarantee Python 3.7 support ([#88](https://github.com/springload/draftjs_exporter/pull/88)).
-* Add upper bound to lxml dependency, now defined as `lxml>=4.2.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
+* Add upper bound to lxml dependency, now defined as `lxml>=3.6.0,<5` ([#75](https://github.com/springload/draftjs_exporter/issues/75)).
 * Update html5lib upper bound, now defined as `html5lib>=0.999,<=1.0.1`.
 
 ## [v2.1.0](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.0)

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'draftjs_exporter'
-__version__ = '2.1.2'
+__version__ = '2.1.3'
 __author__ = 'Springload'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016-present Springload'


### PR DESCRIPTION
* Increase lower bound of optional lxml dependency to v4.2.0 to guarantee Python 3.7 support ([#88](https://github.com/springload/draftjs_exporter/pull/88)).