### PR TITLE
upload to test pypi command and small tweaks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,9 @@ make test-ci         # Continuous integration test suite.
 make dev             # Restarts the example whenever a file changes.
 make benchmark       # Runs a one-off performance (speed, memory) benchmark.
 make clean-pyc       # Remove Python file artifacts.
+make sdist           # Builds package version
 make publish         # Publishes a new version to pypi.
+make publish-test    # Publishes a new version to test pypi.
 ```
 
 ### Debugging
@@ -60,6 +62,7 @@ make publish         # Publishes a new version to pypi.
 * Update the [CHANGELOG](https://github.com/springload/draftjs_exporter/CHANGELOG.md).
 * Update the version number in `draftjs_exporter/__init__.py`, following semver.
 * Make a PR and squash merge it.
+* Back on master with the PR merged, use `make publish-test` (confirm, and enter your password, confirm everything good on test.pypi.org).
 * Back on master with the PR merged, use `make publish` (confirm, and enter your password).
 * Finally, go to GitHub and create a release and a tag for the new version.
 * Done!

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,11 @@ clean-pyc: ## Remove Python file artifacts.
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 
-publish: ## Publishes a new version to pypi.
-	rm dist/* && python setup.py sdist && twine upload dist/* && echo 'Success! Go to https://pypi.org/project/draftjs_exporter/ and check that all is well.'
+sdist: ## Builds package version
+	rm dist/* ; python setup.py sdist
+
+publish: sdist ## Publishes a new version to pypi.
+	twine upload dist/* && echo 'Success! Go to https://pypi.org/project/draftjs_exporter/ and check that all is well.'
+
+publish-test: sdist ## Publishes a new version to test pypi.
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/* && echo 'Success! Go to https://test.pypi.org/project/draftjs_exporter/ and check that all is well.'

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ dependencies['testing'] = [
     'isort==4.2.5',
 ] + dependencies['html5lib'] + dependencies['lxml']
 
-long_description = io.open('README.md', encoding='utf-8').read()
+with io.open('README.md', encoding='utf-8') as readme_file:
+    long_description = readme_file.read()
 
 setup(
     name='draftjs_exporter',


### PR DESCRIPTION
Small changes I made during investigating #103 
- `make publish-test` command added to push to test pypi
- `make sdist` command added to share the build command
    - uses `rm dist/* ; python setup.py sdist` instead of `rm dist/* && python setup.py sdist` because `rm` may fail if `dist/` directory empty
- use `with open` to close `README.md` file