### PR TITLE
Release v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## [v2.1.4](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.4)
+
+### Changed
+
+* Attempt to fix project description formatting on [PyPI](https://pypi.org/project/draftjs_exporter/), broken in the last release ([#103](https://github.com/springload/draftjs_exporter/issues/103)).
+
 ## [v2.1.3](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.3)
 
 ### Changed
@@ -14,7 +20,7 @@
 
 ### Changed
 
-*  Use io.open with utf-8 encoding in setup.py. Fix [#98](https://github.com/springload/draftjs_exporter/issues/98) ([#99](https://github.com/springload/draftjs_exporter/pull/99))
+* Use io.open with utf-8 encoding in setup.py. Fix [#98](https://github.com/springload/draftjs_exporter/issues/98) ([#99](https://github.com/springload/draftjs_exporter/pull/99))
 
 ## [v2.1.1](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.1)
 

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'draftjs_exporter'
-__version__ = '2.1.3'
+__version__ = '2.1.4'
 __author__ = 'Springload'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016-present Springload'


### PR DESCRIPTION
Fixes #103 (hopefully).

### Changed

* Attempt to fix project description formatting on [PyPI](https://pypi.org/project/draftjs_exporter/), broken in the last release ([#103](https://github.com/springload/draftjs_exporter/issues/103)).
