### PR TITLE
Minor performance improvements

### DIFF
--- a/draftjs_exporter/engines/string.py
+++ b/draftjs_exporter/engines/string.py
@@ -71,7 +71,7 @@ class DOMString(DOMEngine):
         # This check is necessary because the current wrapper_state implementation
         # has an issue where it inserts elements multiple times.
         # This must be skipped for text, which can be duplicated.
-        is_existing_ref = isinstance(child, Elt) and child in elt.children
+        is_existing_ref = child in elt.children and isinstance(child, Elt)
         if not is_existing_ref:
             elt.children.append(child)
 

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -53,10 +53,13 @@ class EntityState:
                 'type': entity_details['type'],
             }
 
-            nodes = DOM.create_element()
+            if len(self.element_stack) == 1:
+                children = self.element_stack[0]
+            else:
+                children = DOM.create_element()
 
-            for n in self.element_stack:
-                DOM.append_child(nodes, n)
+                for n in self.element_stack:
+                    DOM.append_child(children, n)
 
             self.completed_entity = None
             self.element_stack = []
@@ -65,7 +68,7 @@ class EntityState:
             if self.has_entity():
                 self.element_stack.append(style_node)
 
-            return DOM.create_element(opts.element, props, nodes)
+            return DOM.create_element(opts.element, props, children)
 
         if self.has_entity():
             self.element_stack.append(style_node)

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -58,9 +58,8 @@ class HTML:
         return DOM.render(document)
 
     def render_block(self, block, entity_map, wrapper_state):
-        content = DOM.create_element()
-
         if block['inlineStyleRanges'] or block['entityRanges']:
+            content = DOM.create_element()
             entity_state = EntityState(self.entity_decorators, entity_map)
             style_state = StyleState(self.style_map)
 
@@ -87,11 +86,9 @@ class HTML:
         # Fast track for blocks which do not contain styles nor entities, which is very common.
         else:
             if len(self.composite_decorators) > 0:
-                decorated_node = render_decorators(self.composite_decorators, block['text'], block, wrapper_state.blocks)
+                content = render_decorators(self.composite_decorators, block['text'], block, wrapper_state.blocks)
             else:
-                decorated_node = block['text']
-
-            DOM.append_child(content, decorated_node)
+                content = block['text']
 
         return wrapper_state.element_for(block, content)
 

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -22,6 +22,7 @@ class HTML:
 
         self.entity_decorators = config.get('entity_decorators', {})
         self.composite_decorators = config.get('composite_decorators', [])
+        self.has_decorators = len(self.composite_decorators) > 0
         self.block_map = config.get('block_map', BLOCK_MAP)
         self.style_map = config.get('style_map', STYLE_MAP)
 
@@ -69,7 +70,7 @@ class HTML:
                     style_state.apply(command)
 
                 # Decorators are not rendered inside entities.
-                if text and entity_state.has_no_entity() and len(self.composite_decorators) > 0:
+                if entity_state.has_no_entity() and self.has_decorators:
                     decorated_node = render_decorators(self.composite_decorators, text, block, wrapper_state.blocks)
                 else:
                     decorated_node = text
@@ -85,7 +86,7 @@ class HTML:
                         DOM.append_child(content, styled_node)
         # Fast track for blocks which do not contain styles nor entities, which is very common.
         else:
-            if len(self.composite_decorators) > 0:
+            if self.has_decorators:
                 content = render_decorators(self.composite_decorators, block['text'], block, wrapper_state.blocks)
             else:
                 content = block['text']

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -85,11 +85,10 @@ class HTML:
                     if styled_node != entity_node and entity_state.has_no_entity():
                         DOM.append_child(content, styled_node)
         # Fast track for blocks which do not contain styles nor entities, which is very common.
+        elif self.has_decorators:
+            content = render_decorators(self.composite_decorators, block['text'], block, wrapper_state.blocks)
         else:
-            if self.has_decorators:
-                content = render_decorators(self.composite_decorators, block['text'], block, wrapper_state.blocks)
-            else:
-                content = block['text']
+            content = block['text']
 
         return wrapper_state.element_for(block, content)
 


### PR DESCRIPTION
Most of those improvements are fairly small. They amount to skipping operations that are not necessary in simple / more common content patterns – for example, blocks not having any styles or entities, or entities not containing anything beyond text.

The speed gain is about 8%. There also seems to be a 20% decrease in memory consumption.

Before:

```
python benchmark.py
Exporting 792 ContentStates 500 times
         303087001 function calls (281316001 primitive calls) in 159.333 seconds
```

After:

```
python benchmark.py
Exporting 792 ContentStates 500 times
         261211501 function calls (247228001 primitive calls) in 146.123 seconds
```