### PR TITLE
Release v2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## Unreleased
 
+## [v2.1.5](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.5)
+
+### Changed
+
+* Minor performance improvements (8% speed-up, 20% lower memory consumption) ([#108](https://github.com/springload/draftjs_exporter/pull/108))
+
+### Fixed
+
+* Fix export bug with adjacent entities - the exporter moved their contents outside of the entities' markup ([#106](https://github.com/springload/draftjs_exporter/pull/106), [#107](https://github.com/springload/draftjs_exporter/pull/107)). Thanks to [@ericpai](https://github.com/ericpai) for reporting this.
+
 ## [v2.1.4](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.4)
 
 ### Changed

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'draftjs_exporter'
-__version__ = '2.1.4'
+__version__ = '2.1.5'
 __author__ = 'Springload'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016-present Springload'


### PR DESCRIPTION
### Changed

* Minor performance improvements (8% speed-up, 20% lower memory consumption) ([#108](https://github.com/springload/draftjs_exporter/pull/108))

### Fixed

* Fix export bug with adjacent entities - the exporter moved their contents outside of the entities' markup ([#106](https://github.com/springload/draftjs_exporter/pull/106), [#107](https://github.com/springload/draftjs_exporter/pull/107)). Thanks to [@ericpai](https://github.com/ericpai) for reporting this.
