### PR TITLE
Assume block depth of 0 if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ## Unreleased
 
+### Changed
+
+* Assume same block defaults as Draft.js would when attributes are missing: depth = 0, type = unstyled, no entities, no styles ([#110](https://github.com/springload/draftjs_exporter/pull/110)).
+
 ## [v2.1.5](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.5)
 
 ### Changed
 
 * Minor performance improvements (8% speed-up, 20% lower memory consumption) ([#108](https://github.com/springload/draftjs_exporter/pull/108))
-* Assume default block depth of 0 ([#110](https://github.com/springload/draftjs_exporter/pull/110))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 * Minor performance improvements (8% speed-up, 20% lower memory consumption) ([#108](https://github.com/springload/draftjs_exporter/pull/108))
+* Assume default block depth of 0 ([#110](https://github.com/springload/draftjs_exporter/pull/110))
 
 ### Fixed
 

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -42,7 +42,8 @@ class HTML:
         min_depth = 0
 
         for block in blocks:
-            depth = block.get('depth', 0)
+            # Assume a depth of 0 if it's not specified, like Draft.js would.
+            depth = block['depth'] if 'depth' in block else 0
             elt = self.render_block(block, entity_map, wrapper_state)
 
             if depth > min_depth:
@@ -59,7 +60,7 @@ class HTML:
         return DOM.render(document)
 
     def render_block(self, block, entity_map, wrapper_state):
-        if block['inlineStyleRanges'] or block['entityRanges']:
+        if 'inlineStyleRanges' in block and block['inlineStyleRanges'] or 'entityRanges' in block and block['entityRanges']:
             content = DOM.create_element()
             entity_state = EntityState(self.entity_decorators, entity_map)
             style_state = StyleState(self.style_map)

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -42,7 +42,7 @@ class HTML:
         min_depth = 0
 
         for block in blocks:
-            depth = block['depth']
+            depth = block.get('depth', 0)
             elt = self.render_block(block, entity_map, wrapper_state)
 
             if depth > min_depth:

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -88,8 +88,8 @@ class WrapperState:
         return '<WrapperState: %s>' % self.stack
 
     def element_for(self, block, block_content):
-        type_ = block['type']
-        depth = block.get('depth', 0)
+        type_ = block['type'] if 'type' in block else 'unstyled'
+        depth = block['depth'] if 'depth' in block else 0
         options = Options.for_block(self.block_map, type_)
         props = dict(options.props)
         props['block'] = block

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -89,7 +89,7 @@ class WrapperState:
 
     def element_for(self, block, block_content):
         type_ = block['type']
-        depth = block['depth']
+        depth = block.get('depth', 0)
         options = Options.for_block(self.block_map, type_)
         props = dict(options.props)
         props['block'] = block

--- a/example.py
+++ b/example.py
@@ -329,13 +329,7 @@ if __name__ == '__main__':
             }],
             "data": {}
         }, {
-            "key": "9fr0j",
             "text": "Here are some features worth highlighting:",
-            "type": "unstyled",
-            "depth": 0,
-            "inlineStyleRanges": [],
-            "entityRanges": [],
-            "data": {}
         }, {
             "key": "2mhgt",
             "text": "Convert line breaks to <br>\nelements.",

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -15,7 +15,7 @@ config = {
             'element': 'li',
             'wrapper': ['ul', {'class': 'public-DraftStyleDefault-ul'}]
         },
-        'unstyled': {'element': 'div'}
+        'unstyled': {'element': 'p'}
     },
     'style_map': {
         'ITALIC': {'element': 'em'},
@@ -293,20 +293,15 @@ class TestHTML(unittest.TestCase):
             ]
         }), '<h1>Header</h1>')
 
-    def test_render_no_depth(self):
-        """Assume a depth of 0 if it's not specified."""
+    def test_render_block_defaults(self):
         self.assertEqual(self.exporter.render({
             'entityMap': {},
             'blocks': [
                 {
-                    'key': '5s7g9',
-                    'text': 'Header',
-                    'type': 'header-one',
-                    'inlineStyleRanges': [],
-                    'entityRanges': []
+                    'text': 'Paragraph',
                 },
             ]
-        }), '<h1>Header</h1>')
+        }), '<p>Paragraph</p>')
 
     def test_render_empty(self):
         self.assertEqual(self.exporter.render({

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -293,6 +293,21 @@ class TestHTML(unittest.TestCase):
             ]
         }), '<h1>Header</h1>')
 
+    def test_render_no_depth(self):
+        """Assume a depth of 0 if it's not specified."""
+        self.assertEqual(self.exporter.render({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'key': '5s7g9',
+                    'text': 'Header',
+                    'type': 'header-one',
+                    'inlineStyleRanges': [],
+                    'entityRanges': []
+                },
+            ]
+        }), '<h1>Header</h1>')
+
     def test_render_empty(self):
         self.assertEqual(self.exporter.render({
             'entityMap': {},


### PR DESCRIPTION
I'm having an issue where DraftJS will generate blocks with no `depth` key at times, for example
```json
{
  "blocks": [{
    "key": "fvkqt",
    "text": "hello world",
    "type": "unstyled",
    "inlineStyleRanges": [],
    "entityRanges": [],
    "data": {}
  }],
  "entityMap": {}
}
```
and parts of this library that assume a `depth` key to be present choke.

Perhaps this is a bug in the client library (I'm on 0.10.5), but I thought I'd open a PR anyway as I'd really like to resolve the issue quickly :sweat_smile: 

Thanks for putting together this library, it could really accelerate development of some features we're working on :slightly_smiling_face: 