### PR TITLE
Release v2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ## Unreleased
 
+## [v2.1.6](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.6)
+
 ### Changed
 
-* Assume same block defaults as Draft.js would when attributes are missing: depth = 0, type = unstyled, no entities, no styles ([#110](https://github.com/springload/draftjs_exporter/pull/110)).
+* Assume same block defaults as Draft.js would when attributes are missing: depth = 0, type = unstyled, no entities, no styles ([#110](https://github.com/springload/draftjs_exporter/pull/110), thanks to [@tpict](https://github.com/tpict)).
 * Minor performance improvements for text-only blocks ([#111](https://github.com/springload/draftjs_exporter/pull/111)).
 
 ## [v2.1.5](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.5)

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'draftjs_exporter'
-__version__ = '2.1.5'
+__version__ = '2.1.6'
 __author__ = 'Springload'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016-present Springload'


### PR DESCRIPTION
## [v2.1.6](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.6)

### Changed

* Assume same block defaults as Draft.js would when attributes are missing: depth = 0, type = unstyled, no entities, no styles ([#110](https://github.com/springload/draftjs_exporter/pull/110)).
* Assume same block defaults as Draft.js would when attributes are missing: depth = 0, type = unstyled, no entities, no styles ([#110](https://github.com/springload/draftjs_exporter/pull/110), thanks to [@tpict](https://github.com/tpict)).