### PR TITLE
Small performance improvements with __slots__ and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-* Minor performance improvements (5% speed-up, 20% lower memory consumption) by adding Python [`__slots__`](https://stackoverflow.com/questions/472000/usage-of-slots)
+* Minor performance improvements (10% speed-up, 30% lower memory consumption) by adding Python [`__slots__`](https://stackoverflow.com/questions/472000/usage-of-slots) and implementing other optimisations.
 
 ## [v2.1.6](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Changed
+
+* Minor performance improvements (5% speed-up, 20% lower memory consumption) by adding Python [`__slots__`](https://stackoverflow.com/questions/472000/usage-of-slots)
+
 ## [v2.1.6](https://github.com/springload/draftjs_exporter/releases/tag/v2.1.6)
 
 ### Changed

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -21,10 +21,6 @@ class Command(object):
         return str(self)
 
     @staticmethod
-    def key(command):
-        return command.index
-
-    @staticmethod
     def start_stop(name, start, stop, data=''):
         """
         Builds a pair of start/stop commands with the same data.

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 
-class Command:
+class Command(object):
     """
     A Command represents an operation that has to be executed
     on a block for it to be converted into an arbitrary number

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -20,9 +20,6 @@ class Command:
     def __repr__(self):
         return str(self)
 
-    def __lt__(self, other):
-        return self.index < other.index
-
     @staticmethod
     def key(command):
         return command.index

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -32,10 +32,10 @@ class Command:
         """
         Builds a pair of start/stop commands with the same data.
         """
-        return [
+        return (
             Command('start_%s' % name, start, data),
             Command('stop_%s' % name, stop, data),
-        ]
+        )
 
     @staticmethod
     def from_ranges(ranges, name, data_key, start_key='offset', length_key='length'):

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -7,6 +7,8 @@ class Command:
     on a block for it to be converted into an arbitrary number
     of HTML nodes.
     """
+    __slots__ = ('name', 'index', 'data')
+
     def __init__(self, name, index, data=''):
         self.name = name
         self.index = index

--- a/draftjs_exporter/constants.py
+++ b/draftjs_exporter/constants.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 
 # http://stackoverflow.com/a/22723724/1798491
 class Enum(object):
+    __slots__ = ('elements')
+
     def __init__(self, *elements):
         self.elements = tuple(elements)
 

--- a/draftjs_exporter/engines/string.py
+++ b/draftjs_exporter/engines/string.py
@@ -14,7 +14,7 @@ except ImportError:
 
 # http://w3c.github.io/html/single-page.html#void-elements
 # https://github.com/html5lib/html5lib-python/blob/0cae52b2073e3f2220db93a7650901f2200f2a13/html5lib/constants.py#L560
-VOID_ELEMENTS = {
+VOID_ELEMENTS = (
     'area',
     'base',
     'br',
@@ -29,7 +29,7 @@ VOID_ELEMENTS = {
     'source',
     'track',
     'wbr',
-}
+)
 
 
 class Elt(object):

--- a/draftjs_exporter/engines/string.py
+++ b/draftjs_exporter/engines/string.py
@@ -38,6 +38,8 @@ class Elt(object):
     This class doesn't do much, but the exporter relies on
     comparing elements by reference so it's useful nonetheless.
     """
+    __slots__ = ('type', 'attr', 'children', 'markup')
+
     def __init__(self, type_, attr, markup=None):
         self.type = type_
         self.attr = attr

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -10,7 +10,7 @@ class EntityException(ExporterException):
     pass
 
 
-class EntityState:
+class EntityState(object):
     __slots__ = ('entity_options', 'entity_map', 'entity_stack', 'completed_entity', 'element_stack')
 
     def __init__(self, entity_options, entity_map):

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from draftjs_exporter.constants import ENTITY_TYPES
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.error import ExporterException
 from draftjs_exporter.options import Options
@@ -10,10 +11,10 @@ class EntityException(ExporterException):
 
 
 class EntityState:
-    __slots__ = ('entity_decorators', 'entity_map', 'entity_stack', 'completed_entity', 'element_stack')
+    __slots__ = ('entity_options', 'entity_map', 'entity_stack', 'completed_entity', 'element_stack')
 
-    def __init__(self, entity_decorators, entity_map):
-        self.entity_decorators = entity_decorators
+    def __init__(self, entity_options, entity_map):
+        self.entity_options = entity_options
         self.entity_map = entity_map
 
         self.entity_stack = []
@@ -49,7 +50,7 @@ class EntityState:
         # We have a complete (start, stop) entity to render.
         if self.completed_entity is not None:
             entity_details = self.get_entity_details(self.completed_entity)
-            opts = Options.for_entity(self.entity_decorators, entity_details['type'])
+            options = Options.get(self.entity_options, entity_details['type'], ENTITY_TYPES.FALLBACK)
             props = entity_details['data'].copy()
             props['entity'] = {
                 'type': entity_details['type'],
@@ -70,7 +71,7 @@ class EntityState:
             if self.has_entity():
                 self.element_stack.append(style_node)
 
-            return DOM.create_element(opts.element, props, children)
+            return DOM.create_element(options.element, props, children)
 
         if self.has_entity():
             self.element_stack.append(style_node)

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -10,6 +10,8 @@ class EntityException(ExporterException):
 
 
 class EntityState:
+    __slots__ = ('entity_decorators', 'entity_map', 'entity_stack', 'completed_entity', 'element_stack')
+
     def __init__(self, entity_decorators, entity_map):
         self.entity_decorators = entity_decorators
         self.entity_map = entity_map

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -130,7 +130,7 @@ class HTML:
         style_commands = self.build_style_commands(block)
         entity_commands = self.build_entity_commands(block)
 
-        return [Command('start_text', 0)] + sorted(style_commands + entity_commands) + [Command('stop_text', len(block['text']))]
+        return [Command('start_text', 0)] + sorted(style_commands + entity_commands, key=Command.key) + [Command('stop_text', len(block['text']))]
 
     def build_style_commands(self, block):
         ranges = block['inlineStyleRanges']

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -12,7 +12,7 @@ from draftjs_exporter.style_state import StyleState
 from draftjs_exporter.wrapper_state import WrapperState
 
 
-class HTML:
+class HTML(object):
     """
     Entry point of the exporter. Combines entity, wrapper and style state
     to generate the right HTML nodes.

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from itertools import groupby
+from operator import attrgetter
 
 from draftjs_exporter.command import Command
 from draftjs_exporter.composite_decorators import render_decorators
@@ -105,8 +106,8 @@ class HTML(object):
         text = block['text']
 
         commands = self.build_commands(block)
-        grouped = groupby(commands, Command.key)
-        listed = list(groupby(commands, Command.key))
+        grouped = groupby(commands, attrgetter('index'))
+        listed = list(groupby(commands, attrgetter('index')))
         sliced = []
 
         i = 0
@@ -130,7 +131,7 @@ class HTML(object):
         style_commands = self.build_style_commands(block)
         entity_commands = self.build_entity_commands(block)
 
-        return [Command('start_text', 0)] + sorted(style_commands + entity_commands, key=Command.key) + [Command('stop_text', len(block['text']))]
+        return [Command('start_text', 0)] + sorted(style_commands + entity_commands, key=attrgetter('index')) + [Command('stop_text', len(block['text']))]
 
     def build_style_commands(self, block):
         ranges = block['inlineStyleRanges']

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -16,6 +16,8 @@ class HTML:
     Entry point of the exporter. Combines entity, wrapper and style state
     to generate the right HTML nodes.
     """
+    __slots__ = ('entity_decorators', 'composite_decorators', 'has_decorators', 'block_map', 'style_map')
+
     def __init__(self, config=None):
         if config is None:
             config = {}

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -33,6 +33,9 @@ class Options:
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(str(self))
+
     @staticmethod
     def create(kind_map, type_, fallback_key):
         """

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -8,6 +8,9 @@ class Options:
     """
     Facilitates querying configuration from a config map.
     """
+    __slots__ = ('type', 'element', 'props', 'wrapper', 'wrapper_props')
+
+
     def __init__(self, type_, element, props=None, wrapper=None, wrapper_props=None):
         self.type = type_
         self.element = element
@@ -22,7 +25,10 @@ class Options:
         return str(self)
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        """
+        Equality used in test code only, not to be relied on for the exporter.
+        """
+        return str(self) == str(other)
 
     def __ne__(self, other):
         return not self == other

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -27,14 +27,14 @@ class Options:
     def __eq__(self, other):
         """
         Equality used in test code only, not to be relied on for the exporter.
-        """
+    """
         return str(self) == str(other)
 
     def __ne__(self, other):
         return not self == other
 
     @staticmethod
-    def for_kind(kind_map, type_, fallback_key):
+    def create(kind_map, type_, fallback_key):
         """
         Create an Options object from any mapping.
         """
@@ -57,13 +57,31 @@ class Options:
         return opts
 
     @staticmethod
-    def for_block(block_map, type_):
-        return Options.for_kind(block_map, type_, BLOCK_TYPES.FALLBACK)
+    def map(kind_map, fallback_key):
+        options = {}
+        for type_ in kind_map:
+            options[type_] = Options.create(kind_map, type_, fallback_key)
+
+        return options
 
     @staticmethod
-    def for_style(style_map, type_):
-        return Options.for_kind(style_map, type_, INLINE_STYLES.FALLBACK)
+    def map_blocks(block_map):
+        return Options.map(block_map, BLOCK_TYPES.FALLBACK)
 
     @staticmethod
-    def for_entity(entity_map, type_):
-        return Options.for_kind(entity_map, type_, ENTITY_TYPES.FALLBACK)
+    def map_styles(style_map):
+        return Options.map(style_map, INLINE_STYLES.FALLBACK)
+
+    @staticmethod
+    def map_entities(entity_map):
+        return Options.map(entity_map, ENTITY_TYPES.FALLBACK)
+
+    @staticmethod
+    def get(options, type_, fallback_key):
+        try:
+            return options[type_]
+        except KeyError:
+            try:
+                return options[fallback_key]
+            except KeyError:
+                raise ConfigException('"%s" is not in the config and has no fallback' % type_)

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -4,7 +4,7 @@ from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
 from draftjs_exporter.error import ConfigException
 
 
-class Options:
+class Options(object):
     """
     Facilitates querying configuration from a config map.
     """

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -10,6 +10,8 @@ class StyleState:
     Receives inline_style commands, and generates the element's `style`
     attribute from those.
     """
+    __slots__ = ('styles', 'style_map')
+
     def __init__(self, style_map):
         self.styles = []
         self.style_map = style_map

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -5,7 +5,7 @@ from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 
 
-class StyleState:
+class StyleState(object):
     """
     Handles the creation of inline styles on elements.
     Receives inline_style commands, and generates the element's `style`

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from draftjs_exporter.constants import INLINE_STYLES
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 
@@ -10,11 +11,11 @@ class StyleState:
     Receives inline_style commands, and generates the element's `style`
     attribute from those.
     """
-    __slots__ = ('styles', 'style_map')
+    __slots__ = ('styles', 'style_options')
 
-    def __init__(self, style_map):
+    def __init__(self, style_options):
         self.styles = []
-        self.style_map = style_map
+        self.style_options = style_options
 
     def apply(self, command):
         if command.name == 'start_inline_style':
@@ -30,13 +31,13 @@ class StyleState:
         if not self.is_empty():
             # Nest the tags.
             for style in sorted(self.styles, reverse=True):
-                opt = Options.for_style(self.style_map, style)
-                props = dict(opt.props)
+                options = Options.get(self.style_options, style, INLINE_STYLES.FALLBACK)
+                props = dict(options.props)
                 props['block'] = block
                 props['blocks'] = blocks
                 props['inline_style_range'] = {
                     'style': style,
                 }
-                node = DOM.create_element(opt.element, props, node)
+                node = DOM.create_element(options.element, props, node)
 
         return node

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from draftjs_exporter.constants import BLOCK_TYPES
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 
@@ -82,10 +83,10 @@ class WrapperState:
     It sets elements with the right tag, text content, and props.
     It adds a wrapper element around elements, if required.
     """
-    __slots__ = ('block_map', 'blocks', 'stack')
+    __slots__ = ('block_options', 'blocks', 'stack')
 
-    def __init__(self, block_map, blocks):
-        self.block_map = block_map
+    def __init__(self, block_options, blocks):
+        self.block_options = block_options
         self.blocks = blocks
         self.stack = WrapperStack()
 
@@ -95,7 +96,7 @@ class WrapperState:
     def element_for(self, block, block_content):
         type_ = block['type'] if 'type' in block else 'unstyled'
         depth = block['depth'] if 'depth' in block else 0
-        options = Options.for_block(self.block_map, type_)
+        options = Options.get(self.block_options, type_, BLOCK_TYPES.FALLBACK)
         props = dict(options.props)
         props['block'] = block
         props['blocks'] = self.blocks

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -114,7 +114,8 @@ class WrapperState:
             self.stack.stack[-1].last_child = elt
         else:
             # Reset the stack if there is no wrapper.
-            self.stack = WrapperStack()
+            if self.stack.length() > 0:
+                self.stack = WrapperStack()
             parent = elt
 
         return parent

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -5,7 +5,7 @@ from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 
 
-class WrapperStack:
+class WrapperStack(object):
     """
     Stack data structure for element wrappers.
     The bottom of the stack contains the elements closest to the page body.
@@ -43,7 +43,7 @@ class WrapperStack:
         return self.stack[0]
 
 
-class Wrapper:
+class Wrapper(object):
     """
     A wrapper is an element that wraps other nodes. It gets created
     when the depth of a block is different than 0, so the DOM elements
@@ -77,7 +77,7 @@ class Wrapper:
 
 
 
-class WrapperState:
+class WrapperState(object):
     """
     This class does the initial node building for the tree.
     It sets elements with the right tag, text content, and props.

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -10,6 +10,8 @@ class WrapperStack:
     The bottom of the stack contains the elements closest to the page body.
     The top of the stack contains the most nested nodes.
     """
+    __slots__ = ('stack')
+
     def __init__(self):
         self.stack = []
 
@@ -46,6 +48,8 @@ class Wrapper:
     when the depth of a block is different than 0, so the DOM elements
     have the appropriate amount of nesting.
     """
+    __slots__ = ('depth', 'last_child', 'type', 'props', 'elt')
+
     def __init__(self, depth, options=None):
         self.depth = depth
         self.last_child = None
@@ -78,6 +82,7 @@ class WrapperState:
     It sets elements with the right tag, text content, and props.
     It adds a wrapper element around elements, if required.
     """
+    __slots__ = ('block_map', 'blocks', 'stack')
 
     def __init__(self, block_map, blocks):
         self.block_map = block_map

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
+        'Development Status :: 5 - Production/Stable',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -15,9 +15,6 @@ class TestCommand(unittest.TestCase):
     def test_str(self):
         self.assertEqual(str(self.command), '<Command abracadabra 5 shazam>')
 
-    def test_key(self):
-        self.assertEqual(Command.key(self.command), 5)
-
     def test_start_stop(self):
         self.assertEqual(str(Command.start_stop('abracadabra', 0, 5, 'shazam')), str((
             Command('start_abracadabra', 0, 'shazam'),

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -15,12 +15,6 @@ class TestCommand(unittest.TestCase):
     def test_str(self):
         self.assertEqual(str(self.command), '<Command abracadabra 5 shazam>')
 
-    def test_lt_true(self):
-        self.assertTrue(self.command.__lt__(Command('a', 10, 's')))
-
-    def test_lt_false(self):
-        self.assertFalse(self.command.__lt__(Command('a', 0, 's')))
-
     def test_key(self):
         self.assertEqual(Command.key(self.command), 5)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -25,10 +25,10 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(Command.key(self.command), 5)
 
     def test_start_stop(self):
-        self.assertEqual(str(Command.start_stop('abracadabra', 0, 5, 'shazam')), str([
+        self.assertEqual(str(Command.start_stop('abracadabra', 0, 5, 'shazam')), str((
             Command('start_abracadabra', 0, 'shazam'),
             Command('stop_abracadabra', 5, 'shazam'),
-        ]))
+        )))
 
     def test_from_ranges_empty(self):
         self.assertEqual(str(Command.from_ranges([], 'abracadabra', 'style')), str([]))

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -4,6 +4,7 @@ import unittest
 
 from draftjs_exporter.command import Command
 from draftjs_exporter.entity_state import EntityException, EntityState
+from draftjs_exporter.options import Options
 from tests.test_entities import link
 
 entity_decorators = {
@@ -23,7 +24,7 @@ entity_map = {
 
 class TestEntityState(unittest.TestCase):
     def setUp(self):
-        self.entity_state = EntityState(entity_decorators, entity_map)
+        self.entity_state = EntityState(Options.map_entities(entity_decorators), entity_map)
 
     def test_init(self):
         self.assertIsInstance(self.entity_state, EntityState)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -16,62 +16,55 @@ class TestOptions(unittest.TestCase):
     def test_not_eq(self):
         self.assertNotEqual(Options('unordered-list-item', 'li'), Options('unordered-list-item', 'p'))
 
-    def test_for_block_full(self):
-        self.assertEqual(Options.for_block({'unordered-list-item': 'li'}, 'unordered-list-item'), Options('unordered-list-item', 'li'))
+    def test_create_full(self):
+        self.assertEqual(Options.create({'unordered-list-item': 'li'}, 'unordered-list-item', 'fallback'), Options('unordered-list-item', 'li'))
 
-    def test_for_block_half(self):
-        self.assertEqual(Options.for_block({'unordered-list-item': 'li'}, 'unordered-list-item'), Options('unordered-list-item', 'li'))
+    def test_create_half(self):
+        self.assertEqual(Options.create({'unordered-list-item': 'li'}, 'unordered-list-item', 'fallback'), Options('unordered-list-item', 'li'))
 
-    def test_for_block_simplest(self):
-        self.assertEqual(Options.for_block({'unordered-list-item': 'li'}, 'unordered-list-item'), Options('unordered-list-item', 'li'))
+    def test_create_simplest(self):
+        self.assertEqual(Options.create({'unordered-list-item': 'li'}, 'unordered-list-item', 'fallback'), Options('unordered-list-item', 'li'))
 
-    def test_for_block_uses_fallback(self):
-        self.assertEqual(Options.for_block({'header-one': 'h1', 'fallback': 'div'}, 'header-two'), Options('header-two', 'div'))
+    def test_create_uses_fallback(self):
+        self.assertEqual(Options.create({'header-one': 'h1', 'fallback': 'div'}, 'header-two', 'fallback'), Options('header-two', 'div'))
 
-    def test_for_block_raises_missing_type(self):
+    def test_create_raises_missing_type(self):
         with self.assertRaises(ConfigException):
-            Options.for_block({'header-one': 'h1'}, 'header-two')
+            Options.create({'header-one': 'h1'}, 'header-two', 'fallback')
 
-    def test_for_block_raises_missing_element(self):
+    def test_create_raises_missing_element(self):
         with self.assertRaises(ConfigException):
-            Options.for_block({'header-one': {}}, 'header-one')
+            Options.create({'header-one': {}}, 'header-one', 'fallback')
 
-    def test_for_style_full(self):
-        self.assertEqual(Options.for_style({'ITALIC': 'em'}, 'ITALIC'), Options('ITALIC', 'em'))
+    def test_map_works(self):
+        self.assertEqual(Options.map({
+            'BOLD': 'strong',
+            'HIGHLIGHT': {
+                'element': 'strong',
+                'props': {'style': {'textDecoration': 'underline'}},
+            },
+        }, 'FALLBACK'), {
+            'BOLD': Options('BOLD', 'strong'),
+            'HIGHLIGHT': Options('HIGHLIGHT', 'strong', props={'style': {'textDecoration': 'underline'}}),
+        })
 
-    def test_for_style_half(self):
-        self.assertEqual(Options.for_style({'ITALIC': 'em'}, 'ITALIC'), Options('ITALIC', 'em'))
+    def test_get_works(self):
+        self.assertEqual(Options.get(Options.map({
+            'BOLD': 'strong',
+            'HIGHLIGHT': {
+                'element': 'strong',
+                'props': {'style': {'textDecoration': 'underline'}},
+            },
+        }, 'FALLBACK'), 'BOLD', 'FALLBACK'), Options('BOLD', 'strong'))
 
-    def test_for_style_simplest(self):
-        self.assertEqual(Options.for_style({'ITALIC': 'em'}, 'ITALIC'), Options('ITALIC', 'em'))
-
-    def test_for_style_uses_fallback(self):
-        self.assertEqual(Options.for_style({'BOLD': 'strong', 'FALLBACK': 'span'}, 'CODE'), Options('CODE', 'span'))
-
-    def test_for_style_raises_missing_type(self):
+    def test_get_raises_exception(self):
         with self.assertRaises(ConfigException):
-            Options.for_style({'BOLD': 'strong'}, 'CODE')
+            self.assertEqual(Options.get(Options.map({
+                'BOLD': 'strong',
+            }, 'FALLBACK'), 'ITALIC', 'FALLBACK'), Options('BOLD', 'strong'))
 
-    def test_for_style_raises_missing_element(self):
-        with self.assertRaises(ConfigException):
-            Options.for_style({'BOLD': {}}, 'BOLD')
-
-    def test_for_entity_full(self):
-        self.assertEqual(Options.for_entity({'HORIZONTAL_RULE': 'hr'}, 'HORIZONTAL_RULE'), Options('HORIZONTAL_RULE', 'hr'))
-
-    def test_for_entity_half(self):
-        self.assertEqual(Options.for_entity({'HORIZONTAL_RULE': 'hr'}, 'HORIZONTAL_RULE'), Options('HORIZONTAL_RULE', 'hr'))
-
-    def test_for_entity_simplest(self):
-        self.assertEqual(Options.for_entity({'HORIZONTAL_RULE': 'hr'}, 'HORIZONTAL_RULE'), Options('HORIZONTAL_RULE', 'hr'))
-
-    def test_for_entity_uses_fallback(self):
-        self.assertEqual(Options.for_entity({'HORIZONTAL_RULE': 'hr', 'FALLBACK': 'div'}, 'TEST'), Options('TEST', 'div'))
-
-    def test_for_entity_raises_missing_type(self):
-        with self.assertRaises(ConfigException):
-            Options.for_entity({'HORIZONTAL_RULE': 'hr'}, 'TEST')
-
-    def test_for_entity_raises_missing_element(self):
-        with self.assertRaises(ConfigException):
-            Options.for_entity({'HORIZONTAL_RULE': {}}, 'HORIZONTAL_RULE')
+    def test_get_uses_fallback(self):
+        self.assertEqual(Options.get(Options.map({
+            'BOLD': 'strong',
+            'FALLBACK': 'span',
+        }, 'FALLBACK'), 'ITALIC', 'FALLBACK'), Options('FALLBACK', 'span'))

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -16,6 +16,9 @@ class TestOptions(unittest.TestCase):
     def test_not_eq(self):
         self.assertNotEqual(Options('unordered-list-item', 'li'), Options('unordered-list-item', 'p'))
 
+    def test_hash(self):
+        self.assertEqual(hash(Options('unordered-list-item', 'li')), hash(Options('unordered-list-item', 'li')))
+
     def test_create_full(self):
         self.assertEqual(Options.create({'unordered-list-item': 'li'}, 'unordered-list-item', 'fallback'), Options('unordered-list-item', 'li'))
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1050,7 +1050,7 @@ class TestOutput(unittest.TestCase):
             'style_map': {
                 INLINE_STYLES.ITALIC: {'element': 'em'},
                 INLINE_STYLES.BOLD: {'element': 'strong'},
-                'HIGHLIGHT': {'element': 'strong', 'textDecoration': 'underline'},
+                'HIGHLIGHT': {'element': 'strong', 'props': {'style': {'textDecoration': 'underline'}}},
             },
         }).render({
             'entityMap': {},

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -5,6 +5,7 @@ import unittest
 
 from draftjs_exporter.command import Command
 from draftjs_exporter.dom import DOM
+from draftjs_exporter.options import Options
 from draftjs_exporter.style_state import StyleState
 
 Important = lambda props: DOM.create_element('strong', {'style': {'color': 'red'}}, props['children'])
@@ -33,7 +34,7 @@ style_map = {
 class TestStyleState(unittest.TestCase):
     def setUp(self):
         DOM.use(DOM.STRING)
-        self.style_state = StyleState(style_map)
+        self.style_state = StyleState(Options.map_styles(style_map))
 
     def test_init(self):
         self.assertIsInstance(self.style_state, StyleState)
@@ -112,9 +113,9 @@ class TestStyleState(unittest.TestCase):
             self.assertEqual(props['inline_style_range']['style'], 'ITALIC')
             return None
 
-        style_state = StyleState({
+        style_state = StyleState(Options.map_styles({
             'ITALIC': component,
-        })
+        }))
 
         style_state.apply(Command('start_inline_style', 0, 'ITALIC'))
         style_state.render_styles('Test text', blocks[0], blocks)

--- a/tests/test_wrapper_state.py
+++ b/tests/test_wrapper_state.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 
 from draftjs_exporter.dom import DOM
+from draftjs_exporter.options import Options
 from draftjs_exporter.wrapper_state import WrapperState
 from example import blockquote, list_item, ordered_list
 
@@ -11,7 +12,7 @@ class TestWrapperState(unittest.TestCase):
     def setUp(self):
         DOM.use(DOM.STRING)
 
-        self.wrapper_state = WrapperState({
+        self.wrapper_state = WrapperState(Options.map_blocks({
             'header-one': 'h1',
             'unstyled': 'div',
             'atomic': lambda props: props['children'],
@@ -21,7 +22,7 @@ class TestWrapperState(unittest.TestCase):
                 'element': list_item,
                 'wrapper': ordered_list
             },
-        }, [])
+        }), [])
 
     def test_init(self):
         self.assertIsInstance(self.wrapper_state, WrapperState)
@@ -42,7 +43,7 @@ class TestWrapperState(unittest.TestCase):
             self.assertEqual(props['blocks'], blocks)
             self.assertEqual(props['block'], blocks[0])
 
-        WrapperState({'unstyled': unstyled}, blocks).element_for(blocks[0], 'test')
+        WrapperState(Options.map_blocks({'unstyled': unstyled}), blocks).element_for(blocks[0], 'test')
 
     def test_element_for_simple_content(self):
         self.assertEqual(DOM.render_debug(self.wrapper_state.element_for({


### PR DESCRIPTION
This contains a few refactorings that should bring some performance improvements, mostly thanks to [`__slots__`](https://stackoverflow.com/questions/472000/usage-of-slots).

The other main improvement is to move the calculation of options for blocks/types/styles to the initialisation of the exporter instead of the rendering.

All in all this makes the exporter about 10% faster, and reduces memory consumption by 20-50% (hard to measure).