### PR TITLE
Reduce tested versions of lxml to remove flaky tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     lower_bound_deps: lxml==4.2.0
     upper_bound_deps: beautifulsoup4<5
     upper_bound_deps: html5lib<=1.0.1
-    upper_bound_deps: lxml<5
+    upper_bound_deps: lxml<4.4.0
 
 commands =
     make lint


### PR DESCRIPTION
Travis shows failures since lxml 4.4.0 has been released, because of Python 3.4 support being removed and changes to how attributes are sorted in 3.7.

https://travis-ci.org/springload/draftjs_exporter/builds