### PR TITLE
Finish setting up Python 3.8 stable testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,20 @@ matrix:
   include:
   - env: TOXENV=py35-lower_bound_deps
     python: 3.5
-    dist: xenial
   - env: TOXENV=py36-lower_bound_deps
     python: 3.6
   - env: TOXENV=py37-lower_bound_deps
     python: 3.7
   - env: TOXENV=py38-lower_bound_deps
-    python: 3.8-dev
+    python: 3.8
   - env: TOXENV=py35-upper_bound_deps
     python: 3.5
-    dist: xenial
   - env: TOXENV=py36-upper_bound_deps
     python: 3.6
   - env: TOXENV=py37-upper_bound_deps
     python: 3.7
   - env: TOXENV=py38-upper_bound_deps
-    python: 3.8-dev
+    python: 3.8
 install:
 - pip install tox coveralls
 script:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,9 +25,9 @@ make init
 pyenv install --skip-existing 3.5.1
 pyenv install --skip-existing 3.6.3
 pyenv install --skip-existing 3.7.0
-pyenv install --skip-existing 3.8-dev
+pyenv install --skip-existing 3.8.0
 # Make required Python versions available globally.
-pyenv global system 3.5.1 3.6.3 3.7.0 3.8-dev
+pyenv global system 3.5.1 3.6.3 3.7.0 3.8.0
 ```
 
 ### Commands


### PR DESCRIPTION
Updates from 3.8-dev to 3.8 (3.8.0) now that Python 3.8 has officially been released. Also switches over to Ubuntu 18 for Python 3.5 – I thought it wasn’t available but it’s on the list on https://docs.travis-ci.com/user/languages/python/.

---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- ~[ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.~
- [x] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- [x] Linting passes (`make lint`)
- ~[ ] Consider updating documentation. If you don't, tell us why.~
- [x] List the environments / platforms in which you tested your changes. 3.8.0