### PR TITLE
#101 Add type annotations checked with mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ lib64
 # Your own project's ignores
 # -------------------------------------------------
 example.html
+.mypy_cache

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE *.rst *.txt *.md
 global-exclude __pycache__
 global-exclude *.py[co]
-recursive-include draftjs_exporter *.py
+recursive-include draftjs_exporter *.py *.typed
 recursive-exclude tests *

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ init: clean-pyc ## Install dependencies and initialise for development.
 lint: ## Lint the project.
 	flake8 draftjs_exporter tests example.py setup.py
 	isort --check-only --diff --recursive draftjs_exporter tests example.py setup.py
-	MYPYPATH=./stubs mypy draftjs_exporter tests example.py
+	mypy draftjs_exporter tests example.py
 
 test: ## Test the project.
 	python -m unittest discover

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ init: clean-pyc ## Install dependencies and initialise for development.
 lint: ## Lint the project.
 	flake8 draftjs_exporter tests example.py setup.py
 	isort --check-only --diff --recursive draftjs_exporter tests example.py setup.py
+	MYPYPATH=./stubs mypy draftjs_exporter tests example.py
 
 test: ## Test the project.
 	python -m unittest discover

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The initial use case was to gain more control over the content managed by rich t
 
 ## Features
 
-This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html), and [measures performance](https://thib.me/python-memory-profiling-for-the-draft-js-exporter) and [code coverage](https://coveralls.io/github/springload/draftjs_exporter).
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html), and [measures performance](https://thib.me/python-memory-profiling-for-the-draft-js-exporter) and [code coverage](https://coveralls.io/github/springload/draftjs_exporter). Code is checked with [mypy](https://mypy.readthedocs.io/en/latest/index.html).
 
 * Extensive configuration of the generated HTML.
 * Default, extensible block & inline style maps for common HTML elements.
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 * Nested lists (`<li>` elements go inside `<ul>` or `<ol>`, with multiple levels).
 * Output inline styles as inline elements (`<em>`, `<strong>`, pick and choose, with any attribute).
 * Overlapping inline style and entity ranges.
+* Python 3.5+ type annotations.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -260,8 +260,7 @@ config = {
 
 ### Custom backing engines
 
-The exporter supports using custom engines to generate its output via the `DOM` API.
-This feature is only used for development at the moment, if you have a use case for this in production we would love to hear from you. Please get in touch!
+The exporter supports using custom engines to generate its output via the `DOM` API. This can be useful to implement custom export formats, e.g. [to Markdown (experimental)](https://github.com/thibaudcolas/draftjs_exporter_markdown).
 
 Here is an example implementation:
 
@@ -290,6 +289,26 @@ exporter = HTML({
     # Use the dotted module syntax to point to the DOMEngine implementation.
     'engine': 'myproject.example.DOMListTree'
 })
+```
+
+### Type annotations
+
+The exporter’s codebase is typed with annotations from the Python 3.5+ standard library, checked with mypy. Reusable types are made available:
+
+```python
+from draftjs_exporter.dom import DOM
+from draftjs_exporter.types import Element, Props
+
+
+# Components are simple functions that take `props` as parameter and return DOM elements.
+def image(props: Props) -> Element:
+    # This component creates an image element, with the relevant attributes.
+    return DOM.create_element('img', {
+        'src': props.get('src'),
+        'width': props.get('width'),
+        'height': props.get('height'),
+        'alt': props.get('alt'),
+    })
 ```
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,10 @@ All supported Python versions should be tested.
 
 Each version should be tested with the lower and upper bounds of supported version ranges for all dependencies.
 
+### Static typing
+
+All exporter code should pass static type checking by [mypy](https://mypy.readthedocs.io/en/latest/index.html), with as strict of a configuration as possible.
+
 ## Troubleshooting
 
 ### Install

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, List, Mapping, Sequence, Tuple
 
 
 class Command(object):
@@ -9,19 +9,19 @@ class Command(object):
     """
     __slots__ = ('name', 'index', 'data')
 
-    def __init__(self, name: str, index: int, data: Optional[str] = ''):
+    def __init__(self, name: str, index: int, data: str = '') -> None:
         self.name = name
         self.index = index
         self.data = data
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '<Command {0} {1} {2}>'.format(self.name, self.index, self.data)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
     @staticmethod
-    def start_stop(name: str, start: int, stop: int, data: Optional[str] = ''):
+    def start_stop(name: str, start: int, stop: int, data: str = '') -> Tuple['Command', 'Command']:
         """
         Builds a pair of start/stop commands with the same data.
         """
@@ -31,15 +31,15 @@ class Command(object):
         )
 
     @staticmethod
-    def from_ranges(ranges: List[Dict[str, Union[int, str]]], name: str, data_key: str, start_key: Optional[str] = 'offset', length_key: Optional[str] = 'length'):
+    def from_ranges(ranges: Sequence[Mapping[str, Any]], name: str, data_key: str) -> List['Command']:
         """
         Creates a list of commands from a list of ranges. Each range
         is converted to two commands: a start_* and a stop_*.
         """
-        commands = []
+        commands: List['Command'] = []
         for r in ranges:
             data = r[data_key]
-            start = r[start_key]
-            stop = start + r[length_key]
+            start = r['offset']
+            stop = start + r['length']
             commands.extend(Command.start_stop(name, start, stop, data))
         return commands

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Optional, Union
+
 
 class Command(object):
     """
@@ -7,7 +9,7 @@ class Command(object):
     """
     __slots__ = ('name', 'index', 'data')
 
-    def __init__(self, name, index, data=''):
+    def __init__(self, name: str, index: int, data: Optional[str] = ''):
         self.name = name
         self.index = index
         self.data = data
@@ -19,7 +21,7 @@ class Command(object):
         return str(self)
 
     @staticmethod
-    def start_stop(name, start, stop, data=''):
+    def start_stop(name: str, start: int, stop: int, data: Optional[str] = ''):
         """
         Builds a pair of start/stop commands with the same data.
         """
@@ -29,7 +31,7 @@ class Command(object):
         )
 
     @staticmethod
-    def from_ranges(ranges, name, data_key, start_key='offset', length_key='length'):
+    def from_ranges(ranges: List[Dict[str, Union[int, str]]], name: str, data_key: str, start_key: Optional[str] = 'offset', length_key: Optional[str] = 'length'):
         """
         Creates a list of commands from a list of ranges. Each range
         is converted to two commands: a start_* and a stop_*.

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -1,4 +1,6 @@
-from typing import Any, List, Mapping, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Sequence, Tuple
+
+Data = str
 
 
 class Command(object):
@@ -9,7 +11,7 @@ class Command(object):
     """
     __slots__ = ('name', 'index', 'data')
 
-    def __init__(self, name: str, index: int, data: str = '') -> None:
+    def __init__(self, name: str, index: int, data: Data = '') -> None:
         self.name = name
         self.index = index
         self.data = data
@@ -21,7 +23,7 @@ class Command(object):
         return str(self)
 
     @staticmethod
-    def start_stop(name: str, start: int, stop: int, data: str = '') -> Tuple['Command', 'Command']:
+    def start_stop(name: str, start: int, stop: int, data: Data = '') -> Tuple['Command', 'Command']:
         """
         Builds a pair of start/stop commands with the same data.
         """

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -36,7 +36,7 @@ class Command(object):
         Creates a list of commands from a list of ranges. Each range
         is converted to two commands: a start_* and a stop_*.
         """
-        commands: List['Command'] = []
+        commands = []  # type: List['Command']
         for r in ranges:
             data = r[data_key]
             start = r['offset']

--- a/draftjs_exporter/command.py
+++ b/draftjs_exporter/command.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Sequence, Tuple
+from typing import Any, List, Mapping, Sequence, Tuple, Union
 
 
 class Command(object):

--- a/draftjs_exporter/composite_decorators.py
+++ b/draftjs_exporter/composite_decorators.py
@@ -1,9 +1,12 @@
 from operator import itemgetter
+from typing import Any, Dict, Generator, List, Sequence, Tuple
+
 from draftjs_exporter.dom import DOM
+from draftjs_exporter.types import Block, CompositeDecorators, Decorator, Element
 
 
-def get_decorations(decorators, text):
-    occupied = {}
+def get_decorations(decorators: CompositeDecorators, text: str) -> List[Tuple[int, int, Any, Decorator]]:
+    occupied = {}  # type: Dict[int, int]
     decorations = []
 
     for decorator in decorators:
@@ -19,7 +22,7 @@ def get_decorations(decorators, text):
     return decorations
 
 
-def apply_decorators(decorators, text, block, blocks):
+def apply_decorators(decorators: CompositeDecorators, text: str, block: Block, blocks: Sequence[Block]) -> Generator[str, None, None]:
     decorations = get_decorations(decorators, text)
 
     pointer = 0
@@ -38,7 +41,7 @@ def apply_decorators(decorators, text, block, blocks):
         yield text[pointer:]
 
 
-def render_decorators(decorators, text, block, blocks):
+def render_decorators(decorators: CompositeDecorators, text: str, block: Block, blocks: Sequence[Block]) -> Element:
     decorated_children = list(apply_decorators(decorators, text, block, blocks))
 
     if len(decorated_children) == 1:

--- a/draftjs_exporter/constants.py
+++ b/draftjs_exporter/constants.py
@@ -1,3 +1,13 @@
+from typing import Any, Callable, Dict, Mapping, Union
+
+Element = Any
+Props = Dict[str, Any]
+
+Tag = str
+Component = Callable[[Props], Element]
+RenderableType = Union[None, str, Component]
+
+
 # http://stackoverflow.com/a/22723724/1798491
 class Enum(object):
     __slots__ = ('elements')

--- a/draftjs_exporter/constants.py
+++ b/draftjs_exporter/constants.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Mapping, Union
+from typing import Any, Callable, Dict, Union
 
 Element = Any
 Props = Dict[str, Any]

--- a/draftjs_exporter/constants.py
+++ b/draftjs_exporter/constants.py
@@ -2,7 +2,7 @@
 class Enum(object):
     __slots__ = ('elements')
 
-    def __init__(self, *elements: str):
+    def __init__(self, *elements: str) -> None:
         self.elements = tuple(elements)
 
     def __getattr__(self, name: str) -> str:

--- a/draftjs_exporter/constants.py
+++ b/draftjs_exporter/constants.py
@@ -1,13 +1,3 @@
-from typing import Any, Callable, Dict, Union
-
-Element = Any
-Props = Dict[str, Any]
-
-Tag = str
-Component = Callable[[Props], Element]
-RenderableType = Union[None, str, Component]
-
-
 # http://stackoverflow.com/a/22723724/1798491
 class Enum(object):
     __slots__ = ('elements')

--- a/draftjs_exporter/constants.py
+++ b/draftjs_exporter/constants.py
@@ -2,10 +2,10 @@
 class Enum(object):
     __slots__ = ('elements')
 
-    def __init__(self, *elements):
+    def __init__(self, *elements: str):
         self.elements = tuple(elements)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> str:
         if name not in self.elements:
             raise AttributeError("'Enum' has no attribute '{}'".format(name))
 

--- a/draftjs_exporter/defaults.py
+++ b/draftjs_exporter/defaults.py
@@ -1,6 +1,4 @@
-from typing import Any, Mapping
-
-from draftjs_exporter.constants import BLOCK_TYPES, Element, INLINE_STYLES, Props
+from draftjs_exporter.constants import BLOCK_TYPES, INLINE_STYLES, Element, Props
 from draftjs_exporter.dom import DOM
 
 

--- a/draftjs_exporter/defaults.py
+++ b/draftjs_exporter/defaults.py
@@ -1,8 +1,10 @@
+from typing import Mapping
+
 from draftjs_exporter.constants import BLOCK_TYPES, INLINE_STYLES
 from draftjs_exporter.dom import DOM
 
 
-def render_children(props):
+def render_children(props: Mapping):
     """
     Renders the children of a component without any specific
     markup for the component itself.
@@ -10,7 +12,7 @@ def render_children(props):
     return props['children']
 
 
-def code_block(props):
+def code_block(props: Mapping):
     return DOM.create_element('pre', {}, DOM.create_element('code', {}, props['children']))
 
 

--- a/draftjs_exporter/defaults.py
+++ b/draftjs_exporter/defaults.py
@@ -1,5 +1,6 @@
-from draftjs_exporter.constants import BLOCK_TYPES, INLINE_STYLES, Element, Props
+from draftjs_exporter.constants import BLOCK_TYPES, INLINE_STYLES
 from draftjs_exporter.dom import DOM
+from draftjs_exporter.types import Element, Props
 
 
 def render_children(props: Props) -> Element:

--- a/draftjs_exporter/defaults.py
+++ b/draftjs_exporter/defaults.py
@@ -1,10 +1,10 @@
-from typing import Mapping
+from typing import Any, Mapping
 
-from draftjs_exporter.constants import BLOCK_TYPES, INLINE_STYLES
+from draftjs_exporter.constants import BLOCK_TYPES, Element, INLINE_STYLES, Props
 from draftjs_exporter.dom import DOM
 
 
-def render_children(props: Mapping):
+def render_children(props: Props) -> Element:
     """
     Renders the children of a component without any specific
     markup for the component itself.
@@ -12,7 +12,7 @@ def render_children(props: Mapping):
     return props['children']
 
 
-def code_block(props: Mapping):
+def code_block(props: Props) -> Element:
     return DOM.create_element('pre', {}, DOM.create_element('code', {}, props['children']))
 
 

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -2,9 +2,9 @@ import re
 
 from typing import Any, Optional
 
-from draftjs_exporter.constants import Element, Props, RenderableType
 from draftjs_exporter.engines.base import DOMEngine
 from draftjs_exporter.utils.module_loading import import_string
+from draftjs_exporter.types import Element, HTML, Props, RenderableType
 
 # https://gist.github.com/yahyaKacem/8170675
 _first_cap_re = re.compile(r'(.)([A-Z][a-z]+)')
@@ -36,7 +36,7 @@ class DOM(object):
         cls.dom = import_string(engine)
 
     @classmethod
-    def create_element(cls, type_: RenderableType = None, props: Props = None, *elt_children: Optional[Element]):
+    def create_element(cls, type_: RenderableType = None, props: Optional[Props] = None, *elt_children: Optional[Element]) -> Element:
         """
         Signature inspired by React.createElement.
         createElement(
@@ -107,7 +107,7 @@ class DOM(object):
         return elt
 
     @classmethod
-    def parse_html(cls, markup: str) -> Element:
+    def parse_html(cls, markup: HTML) -> Element:
         return cls.dom.parse_html(markup)
 
     @classmethod
@@ -115,9 +115,9 @@ class DOM(object):
         return cls.dom.append_child(elt, child)
 
     @classmethod
-    def render(cls, elt: Element) -> str:
+    def render(cls, elt: Element) -> HTML:
         return cls.dom.render(elt)
 
     @classmethod
-    def render_debug(cls, elt: Element) -> str:
+    def render_debug(cls, elt: Element) -> HTML:
         return cls.dom.render_debug(elt)

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from draftjs_exporter.engines.base import DOMEngine
 from draftjs_exporter.utils.module_loading import import_string
-from draftjs_exporter.types import Element, HTML, Props, RenderableType
+from draftjs_exporter.types import HTML, Element, Props, RenderableType
 
 # https://gist.github.com/yahyaKacem/8170675
 _first_cap_re = re.compile(r'(.)([A-Z][a-z]+)')

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -1,5 +1,9 @@
 import re
 
+from typing import Any, Callable, Mapping, Optional, Union
+
+from draftjs_exporter.constants import Element, Props, RenderableType
+from draftjs_exporter.engines.base import DOMEngine
 from draftjs_exporter.utils.module_loading import import_string
 
 # https://gist.github.com/yahyaKacem/8170675
@@ -16,23 +20,23 @@ class DOM(object):
     LXML = 'draftjs_exporter.engines.lxml.DOM_LXML'
     STRING = 'draftjs_exporter.engines.string.DOMString'
 
-    dom = None
+    dom = None  # type: DOMEngine
 
     @staticmethod
-    def camel_to_dash(camel_cased_str):
+    def camel_to_dash(camel_cased_str: str) -> str:
         sub2 = _first_cap_re.sub(r'\1-\2', camel_cased_str)
         dashed_case_str = _all_cap_re.sub(r'\1-\2', sub2).lower()
         return dashed_case_str.replace('--', '-')
 
     @classmethod
-    def use(cls, engine):
+    def use(cls, engine: str) -> None:
         """
         Choose which DOM implementation to use.
         """
         cls.dom = import_string(engine)
 
     @classmethod
-    def create_element(cls, type_=None, props=None, *children):
+    def create_element(cls, type_: RenderableType = None, props: Props = None, *children: Optional[Element]):
         """
         Signature inspired by React.createElement.
         createElement(
@@ -101,17 +105,17 @@ class DOM(object):
         return elt
 
     @classmethod
-    def parse_html(cls, markup):
+    def parse_html(cls, markup: str) -> Element:
         return cls.dom.parse_html(markup)
 
     @classmethod
-    def append_child(cls, elt, child):
+    def append_child(cls, elt: Element, child: Element) -> Any:
         return cls.dom.append_child(elt, child)
 
     @classmethod
-    def render(cls, elt):
+    def render(cls, elt: Element) -> str:
         return cls.dom.render(elt)
 
     @classmethod
-    def render_debug(cls, elt):
+    def render_debug(cls, elt: Element) -> str:
         return cls.dom.render_debug(elt)

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -1,6 +1,6 @@
 import re
 
-from typing import Any, Callable, Mapping, Optional, Union
+from typing import Any, Optional
 
 from draftjs_exporter.constants import Element, Props, RenderableType
 from draftjs_exporter.engines.base import DOMEngine
@@ -36,7 +36,7 @@ class DOM(object):
         cls.dom = import_string(engine)
 
     @classmethod
-    def create_element(cls, type_: RenderableType = None, props: Props = None, *children: Optional[Element]):
+    def create_element(cls, type_: RenderableType = None, props: Props = None, *elt_children: Optional[Element]):
         """
         Signature inspired by React.createElement.
         createElement(
@@ -54,8 +54,10 @@ class DOM(object):
             props = {}
 
         # If the first element of children is a list, we use it as the list.
-        if len(children) and isinstance(children[0], (list, tuple)):
-            children = children[0]
+        if len(elt_children) and isinstance(elt_children[0], (list, tuple)):
+            children = elt_children[0]
+        else:
+            children = elt_children
 
         # The children prop is the first child if there is only one.
         props['children'] = children[0] if len(children) == 1 else children

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -3,8 +3,8 @@ import re
 from typing import Any, Optional
 
 from draftjs_exporter.engines.base import DOMEngine
-from draftjs_exporter.utils.module_loading import import_string
 from draftjs_exporter.types import HTML, Element, Props, RenderableType
+from draftjs_exporter.utils.module_loading import import_string
 
 # https://gist.github.com/yahyaKacem/8170675
 _first_cap_re = re.compile(r'(.)([A-Z][a-z]+)')

--- a/draftjs_exporter/engines/base.py
+++ b/draftjs_exporter/engines/base.py
@@ -1,3 +1,7 @@
+from typing import Any, Dict, Optional
+
+from draftjs_exporter.constants import Element
+
 
 class DOMEngine(object):
     """
@@ -5,14 +9,14 @@ class DOMEngine(object):
     """
 
     @staticmethod
-    def create_tag(type_, attr=None):
+    def create_tag(type_: str, attr: Optional[Dict[str, str]] = None) -> None:
         """
         Creates and returns a tree node of the given type and attributes.
         """
         raise NotImplementedError
 
     @staticmethod
-    def parse_html(markup):
+    def parse_html(markup: str) -> Element:
         """
         Creates nodes based on the input html.
         Note: this method is used in component implementations only, and
@@ -21,21 +25,21 @@ class DOMEngine(object):
         raise NotImplementedError
 
     @staticmethod
-    def append_child(elt, child):
+    def append_child(elt: Element, child: Element) -> Any:
         """
         Appends the given child node in the children of elt.
         """
         raise NotImplementedError
 
     @staticmethod
-    def render(elt):
+    def render(elt: Element) -> str:
         """
         Renders a given element to HTML.
         """
         raise NotImplementedError
 
     @staticmethod
-    def render_debug(elt):
+    def render_debug(elt: Element) -> str:
         """
         Renders a given element to HTML.
         Note: this method is only used for draftjs_exporter's tests, and

--- a/draftjs_exporter/engines/base.py
+++ b/draftjs_exporter/engines/base.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Optional
 
-from draftjs_exporter.types import Element, HTML, Tag
+from draftjs_exporter.types import HTML, Element, Tag
 
-Attr = Optional[Dict[str, str]]
+Attr = Dict[str, str]
 
 
 class DOMEngine(object):
@@ -11,7 +11,7 @@ class DOMEngine(object):
     """
 
     @staticmethod
-    def create_tag(type_: Tag, attr: Attr = None) -> Any:
+    def create_tag(type_: Tag, attr: Optional[Attr] = None) -> Any:
         """
         Creates and returns a tree node of the given type and attributes.
         """

--- a/draftjs_exporter/engines/base.py
+++ b/draftjs_exporter/engines/base.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Optional
 
-from draftjs_exporter.constants import Element
+from draftjs_exporter.types import Element, HTML, Tag
+
+Attr = Optional[Dict[str, str]]
 
 
 class DOMEngine(object):
@@ -9,14 +11,14 @@ class DOMEngine(object):
     """
 
     @staticmethod
-    def create_tag(type_: str, attr: Optional[Dict[str, str]] = None) -> None:
+    def create_tag(type_: Tag, attr: Attr = None) -> Any:
         """
         Creates and returns a tree node of the given type and attributes.
         """
         raise NotImplementedError
 
     @staticmethod
-    def parse_html(markup: str) -> Element:
+    def parse_html(markup: HTML) -> Element:
         """
         Creates nodes based on the input html.
         Note: this method is used in component implementations only, and
@@ -32,14 +34,14 @@ class DOMEngine(object):
         raise NotImplementedError
 
     @staticmethod
-    def render(elt: Element) -> str:
+    def render(elt: Element) -> HTML:
         """
         Renders a given element to HTML.
         """
         raise NotImplementedError
 
     @staticmethod
-    def render_debug(elt: Element) -> str:
+    def render_debug(elt: Element) -> HTML:
         """
         Renders a given element to HTML.
         Note: this method is only used for draftjs_exporter's tests, and

--- a/draftjs_exporter/engines/html5lib.py
+++ b/draftjs_exporter/engines/html5lib.py
@@ -1,6 +1,7 @@
 import re
 
-from draftjs_exporter.engines.base import DOMEngine
+from draftjs_exporter.engines.base import Attr, DOMEngine
+from draftjs_exporter.types import Element, HTML, Tag
 
 try:
     from bs4 import BeautifulSoup
@@ -20,24 +21,24 @@ class DOM_HTML5LIB(DOMEngine):
     """
 
     @staticmethod
-    def create_tag(type_, attr=None):
+    def create_tag(type_: Tag, attr: Attr = None) -> Element:
         if not attr:
             attr = {}
 
         return soup.new_tag(type_, **attr)
 
     @staticmethod
-    def parse_html(markup):
+    def parse_html(markup: HTML) -> Element:
         return BeautifulSoup(markup, 'html5lib')
 
     @staticmethod
-    def append_child(elt, child):
+    def append_child(elt: Element, child: Element) -> None:
         elt.append(child)
 
     @staticmethod
-    def render(elt):
+    def render(elt: Element) -> HTML:
         return RENDER_RE.sub('', str(elt))
 
     @staticmethod
-    def render_debug(elt):
+    def render_debug(elt: Element) -> HTML:
         return RENDER_DEBUG_RE.sub('', str(elt))

--- a/draftjs_exporter/engines/html5lib.py
+++ b/draftjs_exporter/engines/html5lib.py
@@ -1,7 +1,8 @@
 import re
+from typing import Optional
 
 from draftjs_exporter.engines.base import Attr, DOMEngine
-from draftjs_exporter.types import Element, HTML, Tag
+from draftjs_exporter.types import HTML, Element, Tag
 
 try:
     from bs4 import BeautifulSoup
@@ -21,7 +22,7 @@ class DOM_HTML5LIB(DOMEngine):
     """
 
     @staticmethod
-    def create_tag(type_: Tag, attr: Attr = None) -> Element:
+    def create_tag(type_: Tag, attr: Optional[Attr] = None) -> Element:
         if not attr:
             attr = {}
 

--- a/draftjs_exporter/engines/lxml.py
+++ b/draftjs_exporter/engines/lxml.py
@@ -1,6 +1,7 @@
 import re
 
-from draftjs_exporter.engines.base import DOMEngine
+from draftjs_exporter.engines.base import Attr, DOMEngine
+from draftjs_exporter.types import HTML, Tag
 
 try:
     from lxml import etree, html
@@ -19,7 +20,7 @@ class DOM_LXML(DOMEngine):
     lxml implementation of the DOM API.
     """
     @staticmethod
-    def create_tag(type_, attr=None):
+    def create_tag(type_: Tag, attr: Attr = None) -> etree.Element:
         nsmap = None
 
         if attr:
@@ -30,11 +31,11 @@ class DOM_LXML(DOMEngine):
         return etree.Element(type_, attrib=attr, nsmap=nsmap)
 
     @staticmethod
-    def parse_html(markup):
+    def parse_html(markup: HTML) -> etree.Element:
         return html.fromstring(markup)
 
     @staticmethod
-    def append_child(elt, child):
+    def append_child(elt: etree.Element, child: etree.Element) -> None:
         if hasattr(child, 'tag'):
             elt.append(child)
         else:
@@ -43,9 +44,9 @@ class DOM_LXML(DOMEngine):
             elt.append(c)
 
     @staticmethod
-    def render(elt):
+    def render(elt: etree.Element) -> HTML:
         return RENDER_RE.sub('', etree.tostring(elt, method='html', encoding='unicode'))
 
     @staticmethod
-    def render_debug(elt):
+    def render_debug(elt: etree.Element) -> HTML:
         return etree.tostring(elt, method='html', encoding='unicode')

--- a/draftjs_exporter/engines/lxml.py
+++ b/draftjs_exporter/engines/lxml.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from draftjs_exporter.engines.base import Attr, DOMEngine
 from draftjs_exporter.types import HTML, Tag
@@ -20,7 +21,7 @@ class DOM_LXML(DOMEngine):
     lxml implementation of the DOM API.
     """
     @staticmethod
-    def create_tag(type_: Tag, attr: Attr = None) -> etree.Element:
+    def create_tag(type_: Tag, attr: Optional[Attr] = None) -> etree.Element:
         nsmap = None
 
         if attr:

--- a/draftjs_exporter/engines/string.py
+++ b/draftjs_exporter/engines/string.py
@@ -92,7 +92,7 @@ class DOMString(DOMEngine):
             return '<%s%s/>' % (type_, attr)
 
         if type_ == 'escaped_html':
-            return elt.markup
+            return elt.markup  # type: ignore
 
         return '<%s%s>%s</%s>' % (type_, attr, children, type_)
 
@@ -106,6 +106,6 @@ class DOMString(DOMEngine):
             return '<%s%s/>' % (type_, attr)
 
         if type_ == 'escaped_html':
-            return elt.markup
+            return elt.markup  # type: ignore
 
         return '<%s%s>%s</%s>' % (type_, attr, children, type_)

--- a/draftjs_exporter/engines/string.py
+++ b/draftjs_exporter/engines/string.py
@@ -1,6 +1,8 @@
 from html import escape
+from typing import List, Optional, Sequence, Union
 
-from draftjs_exporter.engines.base import DOMEngine
+from draftjs_exporter.engines.base import Attr, DOMEngine
+from draftjs_exporter.types import HTML, Tag
 
 # http://w3c.github.io/html/single-page.html#void-elements
 # https://github.com/html5lib/html5lib-python/blob/0cae52b2073e3f2220db93a7650901f2200f2a13/html5lib/constants.py#L560
@@ -30,14 +32,14 @@ class Elt(object):
     """
     __slots__ = ('type', 'attr', 'children', 'markup')
 
-    def __init__(self, type_, attr, markup=None):
+    def __init__(self, type_: Tag, attr: Optional[Attr], markup: HTML = None):
         self.type = type_
         self.attr = attr
-        self.children = []
+        self.children = []  # type: List['Elt']
         self.markup = markup
 
     @staticmethod
-    def from_html(markup):
+    def from_html(markup: HTML) -> 'Elt':
         return Elt('escaped_html', None, markup)
 
 
@@ -47,11 +49,11 @@ class DOMString(DOMEngine):
     """
 
     @staticmethod
-    def create_tag(type_, attr=None):
+    def create_tag(type_: Tag, attr: Optional[Attr] = None) -> Elt:
         return Elt(type_, attr)
 
     @staticmethod
-    def parse_html(markup):
+    def parse_html(markup: HTML) -> Elt:
         """
         Allows inserting arbitrary HTML into the exporter output.
         Treats the HTML as if it had been escaped and was safe already.
@@ -59,7 +61,7 @@ class DOMString(DOMEngine):
         return Elt.from_html(markup)
 
     @staticmethod
-    def append_child(elt, child):
+    def append_child(elt: Elt, child: Elt) -> None:
         # This check is necessary because the current wrapper_state implementation
         # has an issue where it inserts elements multiple times.
         # This must be skipped for text, which can be duplicated.
@@ -68,17 +70,17 @@ class DOMString(DOMEngine):
             elt.children.append(child)
 
     @staticmethod
-    def render_attrs(attr):
+    def render_attrs(attr: Attr) -> str:
         attrs = [' %s="%s"' % (k, escape(v)) for k, v in attr.items()]
         attrs.sort()
         return ''.join(attrs)
 
     @staticmethod
-    def render_children(children):
+    def render_children(children: Sequence[Union[HTML, Elt]]) -> HTML:
         return ''.join([DOMString.render(c) if isinstance(c, Elt) else escape(c) for c in children])
 
     @staticmethod
-    def render(elt):
+    def render(elt: Elt) -> HTML:
         type_ = elt.type
         attr = DOMString.render_attrs(elt.attr) if elt.attr else ''
         children = DOMString.render_children(elt.children) if elt.children else ''
@@ -95,7 +97,7 @@ class DOMString(DOMEngine):
         return '<%s%s>%s</%s>' % (type_, attr, children, type_)
 
     @staticmethod
-    def render_debug(elt):
+    def render_debug(elt: Elt) -> HTML:
         type_ = elt.type
         attr = DOMString.render_attrs(elt.attr) if elt.attr else ''
         children = DOMString.render_children(elt.children) if elt.children else ''

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -1,14 +1,11 @@
-from typing import Any, List, Mapping, Optional, Union
+from typing import List, Optional
 
 from draftjs_exporter.command import Command
-from draftjs_exporter.constants import ENTITY_TYPES, Element
+from draftjs_exporter.constants import ENTITY_TYPES
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.error import ExporterException
 from draftjs_exporter.options import Options, OptionsMap
-
-EntityKey = Union[str, int]
-EntityDetails = Mapping[str, Any]
-EntityMap = Mapping[str, EntityDetails]
+from draftjs_exporter.types import Element, EntityDetails, EntityKey, EntityMap
 
 
 class EntityException(ExporterException):

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -1,7 +1,14 @@
-from draftjs_exporter.constants import ENTITY_TYPES
+from typing import Any, List, Mapping, Optional, Union
+
+from draftjs_exporter.command import Command
+from draftjs_exporter.constants import ENTITY_TYPES, Element
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.error import ExporterException
-from draftjs_exporter.options import Options
+from draftjs_exporter.options import Options, OptionsMap
+
+EntityKey = Union[str, int]
+EntityDetails = Mapping[str, Any]
+EntityMap = Mapping[str, EntityDetails]
 
 
 class EntityException(ExporterException):
@@ -11,15 +18,15 @@ class EntityException(ExporterException):
 class EntityState(object):
     __slots__ = ('entity_options', 'entity_map', 'entity_stack', 'completed_entity', 'element_stack')
 
-    def __init__(self, entity_options, entity_map):
+    def __init__(self, entity_options: OptionsMap, entity_map: EntityMap) -> None:
         self.entity_options = entity_options
         self.entity_map = entity_map
 
-        self.entity_stack = []
-        self.completed_entity = None
-        self.element_stack = []
+        self.entity_stack = []  # type: List[EntityKey]
+        self.completed_entity = None  # type: Optional[EntityKey]
+        self.element_stack = []  # type: List[Element]
 
-    def apply(self, command):
+    def apply(self, command: Command) -> None:
         if command.name == 'start_entity':
             self.entity_stack.append(command.data)
         elif command.name == 'stop_entity':
@@ -30,13 +37,13 @@ class EntityState(object):
 
             self.completed_entity = self.entity_stack.pop()
 
-    def has_entity(self):
+    def has_entity(self) -> List[EntityKey]:
         return self.entity_stack
 
-    def has_no_entity(self):
+    def has_no_entity(self) -> bool:
         return not self.entity_stack
 
-    def get_entity_details(self, entity_key):
+    def get_entity_details(self, entity_key: EntityKey) -> EntityDetails:
         details = self.entity_map.get(str(entity_key))
 
         if details is None:
@@ -44,7 +51,7 @@ class EntityState(object):
 
         return details
 
-    def render_entities(self, style_node):
+    def render_entities(self, style_node: Element) -> Element:
         # We have a complete (start, stop) entity to render.
         if self.completed_entity is not None:
             entity_details = self.get_entity_details(self.completed_entity)

--- a/draftjs_exporter/entity_state.py
+++ b/draftjs_exporter/entity_state.py
@@ -41,7 +41,7 @@ class EntityState(object):
         return not self.entity_stack
 
     def get_entity_details(self, entity_key: EntityKey) -> EntityDetails:
-        details = self.entity_map.get(str(entity_key))
+        details = self.entity_map.get(entity_key)
 
         if details is None:
             raise EntityException('Entity "%s" does not exist in the entityMap' % entity_key)

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -9,6 +9,8 @@ from draftjs_exporter.entity_state import EntityState
 from draftjs_exporter.options import Options
 from draftjs_exporter.style_state import StyleState
 from draftjs_exporter.wrapper_state import WrapperState
+from typing import Any
+from typing import Dict
 
 
 class HTML(object):
@@ -18,7 +20,7 @@ class HTML(object):
     """
     __slots__ = ('composite_decorators', 'has_decorators', 'entity_options', 'block_options', 'style_options')
 
-    def __init__(self, config=None):
+    def __init__(self, config: Dict[str, Any] = None) -> None:
         if config is None:
             config = {}
 

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -1,15 +1,15 @@
 from itertools import groupby
 from operator import attrgetter
-from typing import Any, Dict, List, Mapping, Tuple
+from typing import List, Optional, Tuple
 
 from draftjs_exporter.command import Command
 from draftjs_exporter.composite_decorators import render_decorators
-from draftjs_exporter.constants import Element
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.entity_state import EntityMap, EntityState
+from draftjs_exporter.entity_state import EntityState
 from draftjs_exporter.options import Options
 from draftjs_exporter.style_state import StyleState
+from draftjs_exporter.types import Block, Config, ContentState, Element, EntityMap
 from draftjs_exporter.wrapper_state import WrapperState
 
 
@@ -20,7 +20,7 @@ class HTML(object):
     """
     __slots__ = ('composite_decorators', 'has_decorators', 'entity_options', 'block_options', 'style_options')
 
-    def __init__(self, config: Dict[str, Any] = None) -> None:
+    def __init__(self, config: Optional[Config] = None) -> None:
         if config is None:
             config = {}
 
@@ -33,7 +33,7 @@ class HTML(object):
 
         DOM.use(config.get('engine', DOM.STRING))
 
-    def render(self, content_state: Mapping[str, Any] = None) -> str:
+    def render(self, content_state: Optional[ContentState] = None) -> str:
         """
         Starts the export process on a given piece of content state.
         """
@@ -64,7 +64,7 @@ class HTML(object):
 
         return DOM.render(document)
 
-    def render_block(self, block: Mapping[str, Any], entity_map: EntityMap, wrapper_state: WrapperState) -> Element:
+    def render_block(self, block: Block, entity_map: EntityMap, wrapper_state: WrapperState) -> Element:
         if 'inlineStyleRanges' in block and block['inlineStyleRanges'] or 'entityRanges' in block and block['entityRanges']:
             content = DOM.create_element()
             entity_state = EntityState(self.entity_options, entity_map)
@@ -98,7 +98,7 @@ class HTML(object):
 
         return wrapper_state.element_for(block, content)
 
-    def build_command_groups(self, block: Mapping[str, Any]) -> List[Tuple[str, List[Command]]]:
+    def build_command_groups(self, block: Block) -> List[Tuple[str, List[Command]]]:
         """
         Creates block modification commands, grouped by start index,
         with the text to apply them on.
@@ -121,7 +121,7 @@ class HTML(object):
 
         return sliced
 
-    def build_commands(self, block: Mapping[str, Any]) -> List[Command]:
+    def build_commands(self, block: Block) -> List[Command]:
         """
         Build all of the manipulation commands for a given block.
         - One pair to set the text.
@@ -135,10 +135,10 @@ class HTML(object):
 
         return [Command('start_text', 0)] + styles_and_entities + [Command('stop_text', len(block['text']))]
 
-    def build_style_commands(self, block: Mapping[str, Any]) -> List[Command]:
+    def build_style_commands(self, block: Block) -> List[Command]:
         ranges = block['inlineStyleRanges']
         return Command.from_ranges(ranges, 'inline_style', 'style')
 
-    def build_entity_commands(self, block: Mapping[str, Any]) -> List[Command]:
+    def build_entity_commands(self, block: Block) -> List[Command]:
         ranges = block['entityRanges']
         return Command.from_ranges(ranges, 'entity', 'key')

--- a/draftjs_exporter/html.py
+++ b/draftjs_exporter/html.py
@@ -128,17 +128,9 @@ class HTML(object):
         - Multiple pairs for styles.
         - Multiple pairs for entities.
         """
-        style_commands = self.build_style_commands(block)
-        entity_commands = self.build_entity_commands(block)
+        style_commands = Command.from_style_ranges(block)
+        entity_commands = Command.from_entity_ranges(block)
         styles_and_entities = style_commands + entity_commands
         styles_and_entities.sort(key=attrgetter('index'))
 
         return [Command('start_text', 0)] + styles_and_entities + [Command('stop_text', len(block['text']))]
-
-    def build_style_commands(self, block: Block) -> List[Command]:
-        ranges = block['inlineStyleRanges']
-        return Command.from_ranges(ranges, 'inline_style', 'style')
-
-    def build_entity_commands(self, block: Block) -> List[Command]:
-        ranges = block['entityRanges']
-        return Command.from_ranges(ranges, 'entity', 'key')

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -1,5 +1,10 @@
-from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
+from typing import Any, Callable, Dict, Optional, Union
+
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Props, RenderableType
 from draftjs_exporter.error import ConfigException
+
+ConfigMap = Dict[str, Union[Dict[str, Any], RenderableType]]
+OptionsMap = Dict[str, 'Options']
 
 
 class Options(object):
@@ -9,7 +14,7 @@ class Options(object):
     __slots__ = ('type', 'element', 'props', 'wrapper', 'wrapper_props')
 
 
-    def __init__(self, type_, element, props=None, wrapper=None, wrapper_props=None):
+    def __init__(self, type_: str, element: RenderableType, props: Optional[Props] = None, wrapper: RenderableType = None, wrapper_props: Optional[Props] = None) -> None:
         self.type = type_
         self.element = element
         self.props = props if props else {}
@@ -35,7 +40,7 @@ class Options(object):
         return hash(str(self))
 
     @staticmethod
-    def create(kind_map, type_, fallback_key):
+    def create(kind_map: ConfigMap, type_: str, fallback_key: str) -> 'Options':
         """
         Create an Options object from any mapping.
         """
@@ -58,7 +63,7 @@ class Options(object):
         return opts
 
     @staticmethod
-    def map(kind_map, fallback_key):
+    def map(kind_map: ConfigMap, fallback_key: str) -> OptionsMap:
         options = {}
         for type_ in kind_map:
             options[type_] = Options.create(kind_map, type_, fallback_key)
@@ -66,19 +71,19 @@ class Options(object):
         return options
 
     @staticmethod
-    def map_blocks(block_map):
+    def map_blocks(block_map: ConfigMap) -> OptionsMap:
         return Options.map(block_map, BLOCK_TYPES.FALLBACK)
 
     @staticmethod
-    def map_styles(style_map):
+    def map_styles(style_map: ConfigMap) -> OptionsMap:
         return Options.map(style_map, INLINE_STYLES.FALLBACK)
 
     @staticmethod
-    def map_entities(entity_map):
+    def map_entities(entity_map: ConfigMap) -> OptionsMap:
         return Options.map(entity_map, ENTITY_TYPES.FALLBACK)
 
     @staticmethod
-    def get(options, type_, fallback_key):
+    def get(options: OptionsMap, type_: str, fallback_key: str):
         try:
             return options[type_]
         except KeyError:

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
-from draftjs_exporter.constants import (
-    BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Props, RenderableType)
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
 from draftjs_exporter.error import ConfigException
+from draftjs_exporter.types import ConfigMap, Props, RenderableType
 
-ConfigMap = Dict[str, Union[Dict[str, Any], RenderableType]]
+# Internal equivalent of a ConfigMap.
 OptionsMap = Dict[str, 'Options']
 
 

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -1,6 +1,7 @@
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
-from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Props, RenderableType
+from draftjs_exporter.constants import (
+    BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Props, RenderableType)
 from draftjs_exporter.error import ConfigException
 
 ConfigMap = Dict[str, Union[Dict[str, Any], RenderableType]]

--- a/draftjs_exporter/options.py
+++ b/draftjs_exporter/options.py
@@ -22,22 +22,22 @@ class Options(object):
         self.wrapper = wrapper
         self.wrapper_props = wrapper_props
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '<Options {0} {1} {2} {3} {4}>'.format(self.type, self.element, self.props, self.wrapper, self.wrapper_props)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """
         Equality used in test code only, not to be relied on for the exporter.
     """
         return str(self) == str(other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not self == other
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(str(self))
 
     @staticmethod
@@ -84,7 +84,7 @@ class Options(object):
         return Options.map(entity_map, ENTITY_TYPES.FALLBACK)
 
     @staticmethod
-    def get(options: OptionsMap, type_: str, fallback_key: str):
+    def get(options: OptionsMap, type_: str, fallback_key: str) -> 'Options':
         try:
             return options[type_]
         except KeyError:

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -1,6 +1,9 @@
-from draftjs_exporter.constants import INLINE_STYLES
+from typing import Any, List, Sequence
+
+from draftjs_exporter.command import Command
+from draftjs_exporter.constants import INLINE_STYLES, Element
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.options import Options
+from draftjs_exporter.options import Options, OptionsMap
 
 
 class StyleState(object):
@@ -11,20 +14,20 @@ class StyleState(object):
     """
     __slots__ = ('styles', 'style_options')
 
-    def __init__(self, style_options):
-        self.styles = []
+    def __init__(self, style_options: OptionsMap) -> None:
+        self.styles = []  # type: List[str]
         self.style_options = style_options
 
-    def apply(self, command):
+    def apply(self, command: Command) -> None:
         if command.name == 'start_inline_style':
             self.styles.append(command.data)
         elif command.name == 'stop_inline_style':
             self.styles.remove(command.data)
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return not self.styles
 
-    def render_styles(self, decorated_node, block, blocks):
+    def render_styles(self, decorated_node: Element, block: Any, blocks: Sequence[Any]) -> Element:
         node = decorated_node
         if not self.is_empty():
             # This will mutate self.styles, but it’s going to be reset after rendering anyway.

--- a/draftjs_exporter/style_state.py
+++ b/draftjs_exporter/style_state.py
@@ -1,9 +1,10 @@
-from typing import Any, List, Sequence
+from typing import List, Sequence
 
 from draftjs_exporter.command import Command
-from draftjs_exporter.constants import INLINE_STYLES, Element
+from draftjs_exporter.constants import INLINE_STYLES
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options, OptionsMap
+from draftjs_exporter.types import Block, Element
 
 
 class StyleState(object):
@@ -27,7 +28,7 @@ class StyleState(object):
     def is_empty(self) -> bool:
         return not self.styles
 
-    def render_styles(self, decorated_node: Element, block: Any, blocks: Sequence[Any]) -> Element:
+    def render_styles(self, decorated_node: Element, block: Block, blocks: Sequence[Block]) -> Element:
         node = decorated_node
         if not self.is_empty():
             # This will mutate self.styles, but it’s going to be reset after rendering anyway.

--- a/draftjs_exporter/types.py
+++ b/draftjs_exporter/types.py
@@ -19,7 +19,7 @@ HTML = str
 Config = Dict[str, Any]
 # block_map, style_map, entity_decorators.
 # The dict could be limited to a fixed set of keys, but this would require TypedDict.
-ConfigMap = Dict[str, Union[Dict[str, Any], RenderableType]]
+ConfigMap = Mapping[str, Union[Dict[str, Any], RenderableType]]
 # composite_decorators.
 Decorator = Dict[str, Any]
 CompositeDecorators = List[Decorator]

--- a/draftjs_exporter/types.py
+++ b/draftjs_exporter/types.py
@@ -29,7 +29,7 @@ ContentState = Mapping[str, Any]
 # Blocks have a predetermined set of keys and values, but let’s be permissive without TypedDict.
 Block = Mapping[str, Any]
 # Entity key is int in blocks, str in Entity map.
-EntityKey = Union[int, str]
+EntityKey = str
 # Entities have fixed keys.
 EntityDetails = Mapping[str, Any]
 EntityMap = Mapping[EntityKey, EntityDetails]

--- a/draftjs_exporter/types.py
+++ b/draftjs_exporter/types.py
@@ -1,0 +1,35 @@
+from typing import Any, Callable, Dict, List, Mapping, Union
+
+# Element represents an instance of a RenderableType. It’s engine-specific so very hard to type.
+Element = Any
+# Props are always a dictionary with string keys and arbitrary values.
+# TODO Other types than string for keys.
+Props = Dict[str, Any]
+
+# A DOM tag name.
+Tag = str
+# A component function, taking props as a parameter and returning an Element by calling DOM.create_element.
+Component = Callable[[Props], Element]
+# What can be rendered: None, DOM tag name, Component.
+RenderableType = Union[None, Tag, Component]
+# The output of the exporter.
+HTML = str
+
+# The whole config object.
+Config = Dict[str, Any]
+# block_map, style_map, entity_decorators.
+# The dict could be limited to a fixed set of keys, but this would require TypedDict.
+ConfigMap = Dict[str, Union[Dict[str, Any], RenderableType]]
+# composite_decorators.
+Decorator = Dict[str, Any]
+CompositeDecorators = List[Decorator]
+
+# The whole content state. blocks and entity_map.
+ContentState = Mapping[str, Any]
+# Blocks have a predetermined set of keys and values, but let’s be permissive without TypedDict.
+Block = Mapping[str, Any]
+# Entity key is int in blocks, str in Entity map.
+EntityKey = Union[int, str]
+# Entities have fixed keys.
+EntityDetails = Mapping[str, Any]
+EntityMap = Mapping[EntityKey, EntityDetails]

--- a/draftjs_exporter/utils/module_loading.py
+++ b/draftjs_exporter/utils/module_loading.py
@@ -1,6 +1,5 @@
-from typing import Any
-
 from importlib import import_module
+from typing import Any
 
 
 def import_string(dotted_path: str) -> Any:

--- a/draftjs_exporter/utils/module_loading.py
+++ b/draftjs_exporter/utils/module_loading.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 
 
-def import_string(dotted_path):
+def import_string(dotted_path: str) -> type:
     """
     Import a dotted module path and return the attribute/class designated by the
     last name in the path. Raise ImportError if the import failed.

--- a/draftjs_exporter/utils/module_loading.py
+++ b/draftjs_exporter/utils/module_loading.py
@@ -1,9 +1,9 @@
+from typing import Any
+
 from importlib import import_module
 
-from draftjs_exporter.engines.base import DOMEngine
 
-
-def import_string(dotted_path: str) -> DOMEngine:
+def import_string(dotted_path: str) -> Any:
     """
     Import a dotted module path and return the attribute/class designated by the
     last name in the path. Raise ImportError if the import failed.

--- a/draftjs_exporter/utils/module_loading.py
+++ b/draftjs_exporter/utils/module_loading.py
@@ -1,7 +1,9 @@
 from importlib import import_module
 
+from draftjs_exporter.engines.base import DOMEngine
 
-def import_string(dotted_path: str) -> type:
+
+def import_string(dotted_path: str) -> DOMEngine:
     """
     Import a dotted module path and return the attribute/class designated by the
     last name in the path. Raise ImportError if the import failed.

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -1,8 +1,9 @@
-from typing import Any, List, Optional, Sequence, Union
+from typing import List, Optional, Sequence, Union
 
-from draftjs_exporter.constants import BLOCK_TYPES, Element, Props, RenderableType
+from draftjs_exporter.constants import BLOCK_TYPES
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options, OptionsMap
+from draftjs_exporter.types import Block, Element, Props, RenderableType
 
 
 class Wrapper(object):
@@ -84,7 +85,7 @@ class WrapperState(object):
     """
     __slots__ = ('block_options', 'blocks', 'stack')
 
-    def __init__(self, block_options: OptionsMap, blocks: Sequence[Any]) -> None:
+    def __init__(self, block_options: OptionsMap, blocks: Sequence[Block]) -> None:
         self.block_options = block_options
         self.blocks = blocks
         self.stack = WrapperStack()
@@ -92,7 +93,7 @@ class WrapperState(object):
     def __str__(self) -> str:
         return '<WrapperState: %s>' % self.stack
 
-    def element_for(self, block: Any, block_content: Union[Element, Sequence[Element]]) -> Element:
+    def element_for(self, block: Block, block_content: Union[Element, Sequence[Element]]) -> Element:
         type_ = block['type'] if 'type' in block else 'unstyled'
         depth = block['depth'] if 'depth' in block else 0
         options = Options.get(self.block_options, type_, BLOCK_TYPES.FALLBACK)
@@ -155,7 +156,7 @@ class WrapperState(object):
                     DOM.append_child(self.stack.head().elt, wrapper_parent)
                 else:
                     # Otherwise we can append at the end of the last child.
-                    wrapper_parent = self.stack.head().last_child
+                    wrapper_parent = self.stack.head().last_child  # type: ignore
 
                 DOM.append_child(wrapper_parent, new_wrapper.elt)
 

--- a/example.py
+++ b/example.py
@@ -627,7 +627,7 @@ if __name__ == '__main__':
     pr.disable()
     p = Stats(pr)
 
-    def prettify(markup):
+    def prettify(markup: str) -> str:
         return re.sub(r'</?(body|html|head)>', '', BeautifulSoup(markup, 'html5lib').prettify()).strip()
 
     pretty = prettify(markup)

--- a/example.py
+++ b/example.py
@@ -5,17 +5,18 @@ import cProfile
 import logging
 import re
 from pstats import Stats
+from typing import Any, Callable, Dict, Optional, Union
 
 from bs4 import BeautifulSoup
 
 # draftjs_exporter provides default configurations and predefined constants for reuse.
-from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
+from draftjs_exporter.constants import BLOCK_TYPES, Element, ENTITY_TYPES, INLINE_STYLES, Props
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.html import HTML
 
 
-def blockquote(props):
+def blockquote(props: Props) -> Element:
     block_data = props['block']['data']
 
     return DOM.create_element('blockquote', {
@@ -23,7 +24,7 @@ def blockquote(props):
     }, props['children'])
 
 
-def list_item(props):
+def list_item(props: Props) -> Element:
     depth = props['block']['depth']
 
     return DOM.create_element('li', {
@@ -31,7 +32,7 @@ def list_item(props):
     }, props['children'])
 
 
-def ordered_list(props):
+def ordered_list(props: Props) -> Element:
     depth = props['block']['depth']
 
     return DOM.create_element('ol', {
@@ -39,7 +40,7 @@ def ordered_list(props):
     }, props['children'])
 
 
-def image(props):
+def image(props: Props) -> Element:
     return DOM.create_element('img', {
         'src': props.get('src'),
         'width': props.get('width'),
@@ -48,13 +49,13 @@ def image(props):
     })
 
 
-def link(props):
+def link(props: Props) -> Element:
     return DOM.create_element('a', {
         'href': props['url']
     }, props['children'])
 
 
-def br(props):
+def br(props: Props) -> Element:
     """
     Replace line breaks (\n) with br tags.
     """
@@ -65,7 +66,7 @@ def br(props):
     return DOM.create_element('br')
 
 
-def hashtag(props):
+def hashtag(props: Props) -> Element:
     """
     Wrap hashtags in spans with a specific class.
     """
@@ -80,7 +81,7 @@ def hashtag(props):
 LINKIFY_RE = re.compile(r'(http://|https://|www\.)([a-zA-Z0-9\.\-%/\?&_=\+#:~!,\'\*\^$]+)')
 
 
-def linkify(props):
+def linkify(props: Props) -> Element:
     """
     Wrap plain URLs with link tags.
     """
@@ -102,7 +103,7 @@ def linkify(props):
     return DOM.create_element('a', link_props, href)
 
 
-def block_fallback(props):
+def block_fallback(props: Props) -> Element:
     type_ = props['block']['type']
 
     if type_ == 'example-discard':
@@ -119,13 +120,13 @@ def block_fallback(props):
         return DOM.create_element('div', {}, props['children'])
 
 
-def entity_fallback(props):
+def entity_fallback(props: Props) -> Element:
     type_ = props['entity']['type']
     logging.warn('Missing config for "%s".' % type_)
     return DOM.create_element('span', {'class': 'missing-entity'}, props['children'])
 
 
-def style_fallback(props):
+def style_fallback(props: Props) -> Element:
     type_ = props['inline_style_range']['style']
     logging.warn('Missing config for "%s". Deleting style.' % type_)
     return props['children']

--- a/example.py
+++ b/example.py
@@ -9,10 +9,11 @@ from pstats import Stats
 from bs4 import BeautifulSoup
 
 # draftjs_exporter provides default configurations and predefined constants for reuse.
-from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Element, Props
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.html import HTML
+from draftjs_exporter.types import Element, Props
 
 
 def blockquote(props: Props) -> Element:

--- a/example.py
+++ b/example.py
@@ -5,12 +5,11 @@ import cProfile
 import logging
 import re
 from pstats import Stats
-from typing import Any, Callable, Dict, Optional, Union
 
 from bs4 import BeautifulSoup
 
 # draftjs_exporter provides default configurations and predefined constants for reuse.
-from draftjs_exporter.constants import BLOCK_TYPES, Element, ENTITY_TYPES, INLINE_STYLES, Props
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, Element, Props
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.html import HTML

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ multi_line_output=4
 [mypy]
 mypy_path = ./stubs
 python_version = 3.5
-pretty = True
 # https://mypy.readthedocs.io/en/latest/config_file.html
 #### Additional opt-in checks of mypy.
 # Disallows usage of types that come from unfollowed imports (anything imported from an unfollowed import is automatically given a type of Any).

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,49 @@ max-line-length = 120
 [isort]
 line_length=100
 multi_line_output=4
+
+[mypy]
+mypy_path = ./stubs
+python_version = 3.5
+pretty = True
+# https://mypy.readthedocs.io/en/latest/config_file.html
+#### Additional opt-in checks of mypy.
+# Disallows usage of types that come from unfollowed imports (anything imported from an unfollowed import is automatically given a type of Any).
+disallow_any_unimported = True
+# Disallows all expressions in the module that have type Any.
+disallow_any_expr = False
+# Disallows functions that have Any in their signature after decorator transformation.
+# disallow_any_decorated = True
+# Disallows explicit Any in type positions such as type annotations and generic type parameters.
+disallow_any_explicit = False
+# Disallows usage of generic types that do not specify explicit type parameters.
+disallow_any_generics = True
+# Disallows subclassing a value of type Any.
+disallow_subclassing_any = True
+
+# Disallows calling functions without type annotations from functions with type annotations.
+disallow_untyped_calls = True
+# Disallows defining functions without type annotations or with incomplete type annotations.
+disallow_untyped_defs = True
+# Disallows defining functions with incomplete type annotations.
+disallow_incomplete_defs = True
+# Type-checks the interior of functions without type annotations.
+check_untyped_defs = True
+# Reports an error whenever a function with type annotations is decorated with a decorator without annotations.
+disallow_untyped_decorators = True
+
+
+# Warns about casting an expression to its inferred type.
+warn_redundant_casts = True
+# Warns about unneeded # type: ignore comments.
+warn_unused_ignores = True
+# Shows errors for missing return statements on some execution paths.
+warn_no_return = True
+# Shows a warning when returning a value with type Any from a function declared with a non- Any return type.
+warn_return_any = True
+# Shows a warning when encountering any code inferred to be unreachable or redundant after performing type analysis.
+warn_unreachable = True
+
+
+# Prohibit equality checks, identity checks, and container checks between non-overlapping types.
+strict_equality = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ disallow_any_unimported = True
 # Disallows all expressions in the module that have type Any.
 disallow_any_expr = False
 # Disallows functions that have Any in their signature after decorator transformation.
-# disallow_any_decorated = True
+disallow_any_decorated = False
 # Disallows explicit Any in type positions such as type annotations and generic type parameters.
 disallow_any_explicit = False
 # Disallows usage of generic types that do not specify explicit type parameters.
@@ -51,3 +51,9 @@ warn_unreachable = True
 
 # Prohibit equality checks, identity checks, and container checks between non-overlapping types.
 strict_equality = True
+
+[mypy-tests.*]
+# For test cases, we don’t need to annotate functions.
+disallow_untyped_defs = False
+# disallow_incomplete_defs = False
+# warn_no_return = False

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ dependencies['testing'] = [
     'coverage==4.5.4',
     'flake8>=3.2.0',
     'isort==4.2.5',
+    'mypy==0.750',
 ] + dependencies['html5lib'] + dependencies['lxml']
 
 with io.open('README.md', encoding='utf-8') as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Editors :: Word Processors',
     ],
+    package_data={
+        'draftjs_exporter': ['py.typed'],
+    },
     install_requires=[],
     extras_require=dependencies,
     zip_safe=False,

--- a/stubs/bs4.pyi
+++ b/stubs/bs4.pyi
@@ -1,0 +1,4 @@
+class BeautifulSoup():
+    def __init__(self, markup: str, features: str): ...  # noqa: E704
+
+    def prettify(self) -> str: ...  # noqa: E704

--- a/stubs/bs4.pyi
+++ b/stubs/bs4.pyi
@@ -1,4 +1,9 @@
+from typing import Any
+
+
 class BeautifulSoup():
-    def __init__(self, markup: str, features: str): ...  # noqa: E704
+    def __init__(self, markup: str, features: str) -> None: ...  # noqa: E704
 
     def prettify(self) -> str: ...  # noqa: E704
+
+    def new_tag(self, type_: str, **attr: Any) -> Any: ...  # noqa: E704

--- a/stubs/lxml/etree.pyi
+++ b/stubs/lxml/etree.pyi
@@ -1,0 +1,18 @@
+from typing import (
+    Dict,
+    Optional,
+)
+from typing_extensions import Literal
+
+
+Attrib = Optional[Dict[str, str]]
+NSMap = Optional[Dict[Literal['xlink'], Literal['http://www.w3.org/1999/xlink']]]
+
+
+class Element():
+    def __init__(self, _tag: str, attrib: Attrib = ..., nsmap: NSMap = ...): ...  # noqa: E704
+
+    def append(self, child: 'Element') -> None: ...  # noqa: E704
+
+
+def tostring(elt: Element, method: Literal['html'], encoding: Literal['unicode']) -> str: ...  # noqa: E704

--- a/stubs/lxml/etree.pyi
+++ b/stubs/lxml/etree.pyi
@@ -9,6 +9,8 @@ NSMap = Optional[Dict[str, str]]
 
 
 class Element():
+    text = None  # type: Optional['Element']
+
     def __init__(self, _tag: str, attrib: Attrib = ..., nsmap: NSMap = ...): ...  # noqa: E704
 
     def append(self, child: 'Element') -> None: ...  # noqa: E704

--- a/stubs/lxml/etree.pyi
+++ b/stubs/lxml/etree.pyi
@@ -2,11 +2,10 @@ from typing import (
     Dict,
     Optional,
 )
-from typing_extensions import Literal
 
 
 Attrib = Optional[Dict[str, str]]
-NSMap = Optional[Dict[Literal['xlink'], Literal['http://www.w3.org/1999/xlink']]]
+NSMap = Optional[Dict[str, str]]
 
 
 class Element():
@@ -15,4 +14,4 @@ class Element():
     def append(self, child: 'Element') -> None: ...  # noqa: E704
 
 
-def tostring(elt: Element, method: Literal['html'], encoding: Literal['unicode']) -> str: ...  # noqa: E704
+def tostring(elt: Element, method: str, encoding: str) -> str: ...  # noqa: E704

--- a/stubs/lxml/html.pyi
+++ b/stubs/lxml/html.pyi
@@ -1,0 +1,4 @@
+from .etree import Element
+
+
+def fromstring(markup: str) -> Element: ...  # noqa: E704

--- a/tests/engines/test_engines_base.py
+++ b/tests/engines/test_engines_base.py
@@ -7,11 +7,11 @@ from draftjs_exporter.engines.base import DOMEngine
 class TestDOMEngine(unittest.TestCase):
     def test_create_tag(self):
         with self.assertRaises(NotImplementedError):
-            DOMEngine.create_tag(None)
+            DOMEngine.create_tag('tag')
 
     def test_parse_html(self):
         with self.assertRaises(NotImplementedError):
-            DOMEngine.parse_html(None)
+            DOMEngine.parse_html('html')
 
     def test_append_child(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/engines/test_engines_string.py
+++ b/tests/engines/test_engines_string.py
@@ -21,8 +21,8 @@ class TestDOMString(unittest.TestCase):
 
     def test_append_child_identical_text(self):
         parent = DOMString.create_tag('p')
-        DOMString.append_child(parent, 'test')
-        DOMString.append_child(parent, 'test')
+        DOMString.append_child(parent, DOMString.parse_html('test'))
+        DOMString.append_child(parent, DOMString.parse_html('test'))
         self.assertEqual(DOMString.render_debug(parent), '<p>testtest</p>')
 
     def test_append_child_identical_elements(self):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -13,42 +13,62 @@ class TestCommand(unittest.TestCase):
     def test_str(self):
         self.assertEqual(str(self.command), '<Command abracadabra 5 shazam>')
 
-    def test_start_stop(self):
-        self.assertEqual(str(Command.start_stop('abracadabra', 0, 5, 'shazam')), str((
-            Command('start_abracadabra', 0, 'shazam'),
-            Command('stop_abracadabra', 5, 'shazam'),
-        )))
 
-    def test_from_ranges_empty(self):
-        self.assertEqual(str(Command.from_ranges([], 'abracadabra', 'style')), str([]))
+    def test_from_style_ranges_empty(self):
+        self.assertEqual(str(Command.from_style_ranges({'inlineStyleRanges': []})), str([]))
 
-    def test_from_ranges_single(self):
-        self.assertEqual(str(Command.from_ranges([
-            {
-                'offset': 0,
-                'length': 4,
-                'style': 'shazam'
-            }
-        ], 'abracadabra', 'style')), str([
-            Command('start_abracadabra', 0, 'shazam'),
-            Command('stop_abracadabra', 4, 'shazam'),
+    def test_from_style_ranges_single(self):
+        self.assertEqual(str(Command.from_style_ranges({
+            'inlineStyleRanges': [
+                {
+                    'offset': 0,
+                    'length': 4,
+                    'style': 'shazam',
+                }
+            ]
+        })), str([
+            Command('start_inline_style', 0, 'shazam'),
+            Command('stop_inline_style', 4, 'shazam'),
         ]))
 
-    def test_from_ranges_multiple(self):
-        self.assertEqual(str(Command.from_ranges([
-            {
-                'offset': 0,
-                'length': 4,
-                'style': 'shazam'
-            },
-            {
-                'offset': 9,
-                'length': 3,
-                'style': 'wazzum'
-            }
-        ], 'abracadabra', 'style')), str([
-            Command('start_abracadabra', 0, 'shazam'),
-            Command('stop_abracadabra', 4, 'shazam'),
-            Command('start_abracadabra', 9, 'wazzum'),
-            Command('stop_abracadabra', 12, 'wazzum'),
+    def test_from_style_ranges_multiple(self):
+        self.assertEqual(str(Command.from_style_ranges({
+            'inlineStyleRanges': [
+                {
+                    'offset': 0,
+                    'length': 4,
+                    'style': 'shazam',
+                },
+                {
+                    'offset': 9,
+                    'length': 3,
+                    'style': 'wazzum',
+                },
+            ],
+        })), str([
+            Command('start_inline_style', 0, 'shazam'),
+            Command('stop_inline_style', 4, 'shazam'),
+            Command('start_inline_style', 9, 'wazzum'),
+            Command('stop_inline_style', 12, 'wazzum'),
+        ]))
+
+    def test_from_entity_ranges_multiple(self):
+        self.assertEqual(str(Command.from_entity_ranges({
+            'entityRanges': [
+                {
+                    'offset': 0,
+                    'length': 4,
+                    'key': 3,
+                },
+                {
+                    'offset': 9,
+                    'length': 3,
+                    'key': 10,
+                },
+            ],
+        })), str([
+            Command('start_entity', 0, '3'),
+            Command('stop_entity', 4, '3'),
+            Command('start_entity', 9, '10'),
+            Command('stop_entity', 12, '10'),
         ]))

--- a/tests/test_composite_decorators.py
+++ b/tests/test_composite_decorators.py
@@ -24,25 +24,25 @@ LINKIFY_DECORATOR = {
 
 class TestLinkify(unittest.TestCase):
     def test_render(self):
-        match = next(LINKIFY_DECORATOR['strategy'].finditer('test https://www.example.com'))
+        match = next(LINKIFY_RE.finditer('test https://www.example.com'))
 
-        self.assertEqual(DOM.render(DOM.create_element(LINKIFY_DECORATOR['component'], {
+        self.assertEqual(DOM.render(DOM.create_element(linkify, {
             'block': {'type': BLOCK_TYPES.UNSTYLED},
             'match': match,
         }, match.group(0))), '<a href="https://www.example.com">https://www.example.com</a>')
 
     def test_render_www(self):
-        match = next(LINKIFY_DECORATOR['strategy'].finditer('test www.example.com'))
+        match = next(LINKIFY_RE.finditer('test www.example.com'))
 
-        self.assertEqual(DOM.render(DOM.create_element(LINKIFY_DECORATOR['component'], {
+        self.assertEqual(DOM.render(DOM.create_element(linkify, {
             'block': {'type': BLOCK_TYPES.UNSTYLED},
             'match': match,
         }, match.group(0))), '<a href="http://www.example.com">www.example.com</a>')
 
     def test_render_code_block(self):
-        match = next(LINKIFY_DECORATOR['strategy'].finditer('test https://www.example.com'))
+        match = next(LINKIFY_RE.finditer('test https://www.example.com'))
 
-        self.assertEqual(DOM.create_element(LINKIFY_DECORATOR['component'], {
+        self.assertEqual(DOM.create_element(linkify, {
             'block': {'type': BLOCK_TYPES.CODE},
             'match': match,
         }, match.group(0)), match.group(0))
@@ -50,18 +50,18 @@ class TestLinkify(unittest.TestCase):
 
 class TestHashtag(unittest.TestCase):
     def test_render(self):
-        self.assertEqual(DOM.render(DOM.create_element(HASHTAG_DECORATOR['component'], {'block': {'type': BLOCK_TYPES.UNSTYLED}}, '#hashtagtest')), '<span class="hashtag">#hashtagtest</span>')
+        self.assertEqual(DOM.render(DOM.create_element(hashtag, {'block': {'type': BLOCK_TYPES.UNSTYLED}}, '#hashtagtest')), '<span class="hashtag">#hashtagtest</span>')
 
     def test_render_code_block(self):
-        self.assertEqual(DOM.create_element(HASHTAG_DECORATOR['component'], {'block': {'type': BLOCK_TYPES.CODE}}, '#hashtagtest'), '#hashtagtest')
+        self.assertEqual(DOM.create_element(hashtag, {'block': {'type': BLOCK_TYPES.CODE}}, '#hashtagtest'), '#hashtagtest')
 
 
 class TestBR(unittest.TestCase):
     def test_render(self):
-        self.assertEqual(DOM.render(DOM.create_element(BR_DECORATOR['component'], {'block': {'type': BLOCK_TYPES.UNSTYLED}}, '\n')), '<br/>')
+        self.assertEqual(DOM.render(DOM.create_element(br, {'block': {'type': BLOCK_TYPES.UNSTYLED}}, '\n')), '<br/>')
 
     def test_render_code_block(self):
-        self.assertEqual(DOM.create_element(BR_DECORATOR['component'], {'block': {'type': BLOCK_TYPES.CODE}}, '\n'), '\n')
+        self.assertEqual(DOM.create_element(br, {'block': {'type': BLOCK_TYPES.CODE}}, '\n'), '\n')
 
 
 class TestCompositeDecorators(unittest.TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,7 +1,6 @@
-from typing import Any, Mapping
 import unittest
 
-from draftjs_exporter.constants import Props, Element
+from draftjs_exporter.constants import Element, Props
 from draftjs_exporter.dom import DOM
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,13 +1,15 @@
+from typing import Any, Mapping
 import unittest
 
+from draftjs_exporter.constants import Props, Element
 from draftjs_exporter.dom import DOM
 
 
-def hr(props):
+def hr(props: Props) -> Element:
     return DOM.create_element('hr')
 
 
-def link(props):
+def link(props: Props) -> Element:
     attributes = {}
     for key in props:
         attr = key if key != 'url' else 'href'
@@ -16,7 +18,7 @@ def link(props):
     return DOM.create_element('a', attributes, props['children'])
 
 
-def image(props):
+def image(props: Props) -> Element:
     return DOM.create_element('img', {
         'src': props.get('src'),
         'width': props.get('width'),
@@ -25,12 +27,12 @@ def image(props):
     })
 
 
-def icon(props):
+def icon(props: Props) -> Element:
     href = '#icon-%s' % props.get('name', '')
     return DOM.create_element('svg', {'class': 'icon'}, DOM.create_element('use', {'xlink:href': href}))
 
 
-def button(props):
+def button(props: Props) -> Element:
     href = props.get('href', '#')
     icon_name = props.get('icon', None)
     text = props.get('text', '')

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,7 +1,7 @@
 import unittest
 
-from draftjs_exporter.constants import Element, Props
 from draftjs_exporter.dom import DOM
+from draftjs_exporter.types import Element, Props
 
 
 def hr(props: Props) -> Element:

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -22,7 +22,7 @@ entity_map = {
 
 class TestEntityState(unittest.TestCase):
     def setUp(self):
-        self.entity_state = EntityState(Options.map_entities(entity_decorators), entity_map)
+        self.entity_state = EntityState(Options.map_entities(entity_decorators), entity_map)  # type: ignore
 
     def test_init(self):
         self.assertIsInstance(self.entity_state, EntityState)

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -22,36 +22,36 @@ entity_map = {
 
 class TestEntityState(unittest.TestCase):
     def setUp(self):
-        self.entity_state = EntityState(Options.map_entities(entity_decorators), entity_map)  # type: ignore
+        self.entity_state = EntityState(Options.map_entities(entity_decorators), entity_map)
 
     def test_init(self):
         self.assertIsInstance(self.entity_state, EntityState)
 
     def test_apply_start_entity(self):
         self.assertEqual(len(self.entity_state.entity_stack), 0)
-        self.entity_state.apply(Command('start_entity', 0, 0))
-        self.assertEqual(self.entity_state.entity_stack[-1], 0)
+        self.entity_state.apply(Command('start_entity', 0, '0'))
+        self.assertEqual(self.entity_state.entity_stack[-1], '0')
 
     def test_apply_stop_entity(self):
         self.assertEqual(len(self.entity_state.entity_stack), 0)
-        self.entity_state.apply(Command('start_entity', 0, 0))
-        self.entity_state.apply(Command('stop_entity', 5, 0))
+        self.entity_state.apply(Command('start_entity', 0, '0'))
+        self.entity_state.apply(Command('stop_entity', 5, '0'))
         self.assertEqual(len(self.entity_state.entity_stack), 0)
 
     def test_apply_raises(self):
         with self.assertRaises(EntityException):
-            self.entity_state.apply(Command('start_entity', 0, 0))
-            self.entity_state.apply(Command('stop_entity', 0, 1))
+            self.entity_state.apply(Command('start_entity', 0, '0'))
+            self.entity_state.apply(Command('stop_entity', 0, '1'))
 
     def test_has_no_entity_default(self):
         self.assertEqual(self.entity_state.has_no_entity(), True)
 
     def test_has_no_entity_styled(self):
-        self.entity_state.apply(Command('start_entity', 0, 0))
+        self.entity_state.apply(Command('start_entity', 0, '0'))
         self.assertEqual(self.entity_state.has_no_entity(), False)
 
     def test_get_entity_details(self):
-        self.assertEqual(self.entity_state.get_entity_details(0), {
+        self.assertEqual(self.entity_state.get_entity_details('0'), {
             'data': {
                 'url': 'http://example.com'
             },
@@ -61,4 +61,4 @@ class TestEntityState(unittest.TestCase):
 
     def test_get_entity_details_raises(self):
         with self.assertRaises(EntityException):
-            self.entity_state.get_entity_details(1)
+            self.entity_state.get_entity_details('1')

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -48,7 +48,7 @@ class TestExportsMeta(type):
     See http://stackoverflow.com/a/20870875/1798491
     """
     def __new__(mcs, name, bases, tests):
-        def gen_test(content, html):
+        def gen_test(content: str, html: str):
             def test(self):
                 self.assertEqual(exporter.render(content), html)
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -5,8 +5,6 @@ import unittest
 from pstats import Stats
 from typing import Callable
 
-import six
-
 from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
 from draftjs_exporter.dom import DOM
@@ -72,7 +70,7 @@ class TestExportsMeta(type):
         return type.__new__(mcs, name, bases, tests)
 
 
-class TestExportsHTML5LIB(six.with_metaclass(TestExportsMeta, unittest.TestCase)):
+class TestExportsHTML5LIB(unittest.TestCase, metaclass=TestExportsMeta):
     @classmethod
     def setUpClass(cls):
         DOM.use(DOM.HTML5LIB)
@@ -86,7 +84,7 @@ class TestExportsHTML5LIB(six.with_metaclass(TestExportsMeta, unittest.TestCase)
         Stats(cls.pr).strip_dirs().sort_stats('cumulative').print_stats(0)
 
 
-class TestExportsLXML(six.with_metaclass(TestExportsMeta, unittest.TestCase)):
+class TestExportsLXML(unittest.TestCase, metaclass=TestExportsMeta):
     @classmethod
     def setUpClass(cls):
         DOM.use(DOM.LXML)
@@ -100,7 +98,7 @@ class TestExportsLXML(six.with_metaclass(TestExportsMeta, unittest.TestCase)):
         Stats(cls.pr).strip_dirs().sort_stats('cumulative').print_stats(0)
 
 
-class TestExportsSTRING(six.with_metaclass(TestExportsMeta, unittest.TestCase)):
+class TestExportsSTRING(unittest.TestCase, metaclass=TestExportsMeta):
     @classmethod
     def setUpClass(cls):
         DOM.use(DOM.STRING)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -50,6 +50,9 @@ class TestExportsMeta(type):
     Generates test cases dynamically.
     See http://stackoverflow.com/a/20870875/1798491
     """
+
+    pr = None  # type: cProfile.Profile
+
     def __new__(mcs, name, bases, tests):
         def gen_test(content: ContentState, html: str) -> Callable[[None], None]:
             def test(self):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,6 +3,7 @@ import json
 import os
 import unittest
 from pstats import Stats
+from typing import Callable
 
 import six
 
@@ -10,6 +11,8 @@ from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES
 from draftjs_exporter.defaults import BLOCK_MAP, STYLE_MAP
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.html import HTML
+from draftjs_exporter.types import ContentState
+
 from tests.test_composite_decorators import BR_DECORATOR, HASHTAG_DECORATOR, LINKIFY_DECORATOR
 from tests.test_entities import hr, image, link
 
@@ -48,7 +51,7 @@ class TestExportsMeta(type):
     See http://stackoverflow.com/a/20870875/1798491
     """
     def __new__(mcs, name, bases, tests):
-        def gen_test(content: str, html: str):
+        def gen_test(content: ContentState, html: str) -> Callable[[None], None]:
             def test(self):
                 self.assertEqual(exporter.render(content), html)
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -36,116 +36,6 @@ class TestHTML(unittest.TestCase):
     def test_render_block_exists(self):
         self.assertTrue('render_block' in dir(self.exporter))
 
-    def test_build_style_commands_empty(self):
-        self.assertEqual(str(self.exporter.build_style_commands({
-            'key': '5s7g9',
-            'text': 'Header',
-            'type': 'header-one',
-            'depth': 0,
-            'inlineStyleRanges': [],
-            'entityRanges': []
-        })), str([]))
-
-    def test_build_style_commands_single(self):
-        self.assertEqual(str(self.exporter.build_style_commands({
-            'key': '5s7g9',
-            'text': 'Header',
-            'type': 'header-one',
-            'depth': 0,
-            'inlineStyleRanges': [
-                {
-                    'offset': 0,
-                    'length': 4,
-                    'style': 'ITALIC'
-                }
-            ],
-            'entityRanges': []
-        })), str([
-            Command('start_inline_style', 0, 'ITALIC'),
-            Command('stop_inline_style', 4, 'ITALIC'),
-        ]))
-
-    def test_build_style_commands_multiple(self):
-        self.assertEqual(str(self.exporter.build_style_commands({
-            'key': '5s7g9',
-            'text': 'Header',
-            'type': 'header-one',
-            'depth': 0,
-            'inlineStyleRanges': [
-                {
-                    'offset': 0,
-                    'length': 4,
-                    'style': 'ITALIC'
-                },
-                {
-                    'offset': 9,
-                    'length': 3,
-                    'style': 'BOLD'
-                }
-            ],
-            'entityRanges': []
-        })), str([
-            Command('start_inline_style', 0, 'ITALIC'),
-            Command('stop_inline_style', 4, 'ITALIC'),
-            Command('start_inline_style', 9, 'BOLD'),
-            Command('stop_inline_style', 12, 'BOLD'),
-        ]))
-
-    def test_build_entity_commands_empty(self):
-        self.assertEqual(str(self.exporter.build_entity_commands({
-            'key': 'dem5p',
-            'text': 'some paragraph text',
-            'type': 'unstyled',
-            'depth': 0,
-            'inlineStyleRanges': [],
-            'entityRanges': []
-        })), str([]))
-
-    def test_build_entity_commands_single(self):
-        self.assertEqual(str(self.exporter.build_entity_commands({
-            'key': 'dem5p',
-            'text': 'some paragraph text',
-            'type': 'unstyled',
-            'depth': 0,
-            'inlineStyleRanges': [],
-            'entityRanges': [
-                {
-                    'offset': 5,
-                    'length': 9,
-                    'key': 0
-                }
-            ]
-        })), str([
-            Command('start_entity', 5, 0),
-            Command('stop_entity', 14, 0),
-        ]))
-
-    def test_build_entity_commands_multiple(self):
-        self.assertEqual(str(self.exporter.build_entity_commands({
-            'key': 'dem5p',
-            'text': 'some paragraph text',
-            'type': 'unstyled',
-            'depth': 0,
-            'inlineStyleRanges': [],
-            'entityRanges': [
-                {
-                    'offset': 5,
-                    'length': 9,
-                    'key': 0
-                },
-                {
-                    'offset': 0,
-                    'length': 4,
-                    'key': 1
-                }
-            ]
-        })), str([
-            Command('start_entity', 5, 0),
-            Command('stop_entity', 14, 0),
-            Command('start_entity', 0, 1),
-            Command('stop_entity', 4, 1),
-        ]))
-
     def test_build_commands_empty(self):
         self.assertEqual(str(self.exporter.build_commands({
             'key': 'dem5p',
@@ -192,13 +82,13 @@ class TestHTML(unittest.TestCase):
         })), str([
             Command('start_text', 0),
             Command('start_inline_style', 0, 'ITALIC'),
-            Command('start_entity', 0, 1),
+            Command('start_entity', 0, '1'),
             Command('stop_inline_style', 4, 'ITALIC'),
-            Command('stop_entity', 4, 1),
-            Command('start_entity', 5, 0),
+            Command('stop_entity', 4, '1'),
+            Command('start_entity', 5, '0'),
             Command('start_inline_style', 9, 'BOLD'),
             Command('stop_inline_style', 12, 'BOLD'),
-            Command('stop_entity', 14, 0),
+            Command('stop_entity', 14, '0'),
             Command('stop_text', 19),
         ]))
 
@@ -253,14 +143,14 @@ class TestHTML(unittest.TestCase):
             ('some', [
                 Command('start_text', 0),
                 Command('start_inline_style', 0, 'ITALIC'),
-                Command('start_entity', 0, 1),
+                Command('start_entity', 0, '1'),
             ]),
             (' ', [
                 Command('stop_inline_style', 4, 'ITALIC'),
-                Command('stop_entity', 4, 1),
+                Command('stop_entity', 4, '1'),
             ]),
             ('para', [
-                Command('start_entity', 5, 0),
+                Command('start_entity', 5, '0'),
             ]),
             ('gra', [
                 Command('start_inline_style', 9, 'BOLD'),
@@ -269,7 +159,7 @@ class TestHTML(unittest.TestCase):
                 Command('stop_inline_style', 12, 'BOLD'),
             ]),
             (' text', [
-                Command('stop_entity', 14, 0),
+                Command('stop_entity', 14, '0'),
             ]),
             ('', [
                 Command('stop_text', 19),

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -1,7 +1,8 @@
-# -*- coding: utf-8 -*-
+from typing import Any, Mapping
 import unittest
 
 from draftjs_exporter.command import Command
+from draftjs_exporter.constants import Props, Element
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 from draftjs_exporter.style_state import StyleState
@@ -9,7 +10,7 @@ from draftjs_exporter.style_state import StyleState
 Important = lambda props: DOM.create_element('strong', {'style': {'color': 'red'}}, props['children'])
 
 
-def Shout(props):
+def Shout(props: Props) -> Element:
     return DOM.create_element('span', {'style': {'textTransform': 'uppercase'}}, props['children'])
 
 

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -1,10 +1,10 @@
 import unittest
 
 from draftjs_exporter.command import Command
-from draftjs_exporter.constants import Element, Props
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 from draftjs_exporter.style_state import StyleState
+from draftjs_exporter.types import Element, Props
 
 Important = lambda props: DOM.create_element('strong', {'style': {'color': 'red'}}, props['children'])
 

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -1,8 +1,7 @@
-from typing import Any, Mapping
 import unittest
 
 from draftjs_exporter.command import Command
-from draftjs_exporter.constants import Props, Element
+from draftjs_exporter.constants import Element, Props
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.options import Options
 from draftjs_exporter.style_state import StyleState

--- a/tests/test_style_state.py
+++ b/tests/test_style_state.py
@@ -32,7 +32,7 @@ style_map = {
 class TestStyleState(unittest.TestCase):
     def setUp(self):
         DOM.use(DOM.STRING)
-        self.style_state = StyleState(Options.map_styles(style_map))
+        self.style_state = StyleState(Options.map_styles(style_map))  # type: ignore
 
     def test_init(self):
         self.assertIsInstance(self.style_state, StyleState)


### PR DESCRIPTION
Background & research: https://thib.me/python-static-type-checking-field-test

---

<!-- See the general contribution guidelines in docs/CONTRIBUTING.md -->

See #101. This adds type annotations to the project, along with static type checking with mypy. This is only using syntax and stdlib types from Python 3.5 or below, to avoid introducing new compatibility hurdles. In the future it would be nice to leverage Python 3.6+ variables annotation syntax, and potentially also types added in Python 3.8 and backported with `typing_extensions`.

---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- [x] Linting passes (`make lint`)
- [x] Consider updating documentation. If you don't, tell us why.
- [x] List the environments / platforms in which you tested your changes.

Thanks for contributing to this project!
