### PR TITLE
Small performance improvements per block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ lib64
 example.html
 .mypy_cache
 pip-wheel-metadata
+__pycache__

--- a/draftjs_exporter/composite_decorators.py
+++ b/draftjs_exporter/composite_decorators.py
@@ -1,3 +1,4 @@
+import re
 from operator import itemgetter
 from typing import Any, Dict, Generator, List, Sequence, Tuple
 
@@ -8,6 +9,9 @@ from draftjs_exporter.types import (
     Decorator,
     Element,
 )
+
+br = "\n"
+br_strategy = re.compile(r"\n")
 
 
 def get_decorations(
@@ -69,3 +73,20 @@ def render_decorators(
             DOM.append_child(decorated_node, decorated_child)
 
     return decorated_node
+
+
+def should_render_decorators(
+    decorators: CompositeDecorators, text: str,
+) -> bool:
+    nb_decorators = len(decorators)
+
+    if nb_decorators == 0:
+        return False
+
+    is_skippable_br = (
+        nb_decorators == 1
+        and decorators[0]["strategy"] == br_strategy
+        and not (br in text)
+    )
+
+    return not is_skippable_br

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -35,7 +35,12 @@ class DOM(object):
         cls.dom = import_string(engine)
 
     @classmethod
-    def create_element(cls, type_: RenderableType = None, props: Optional[Props] = None, *elt_children: Optional[Element]) -> Element:
+    def create_element(
+        cls,
+        type_: RenderableType = None,
+        props: Optional[Props] = None,
+        *elt_children: Optional[Element]
+    ) -> Element:
         """
         Signature inspired by React.createElement.
         createElement(

--- a/draftjs_exporter/wrapper_state.py
+++ b/draftjs_exporter/wrapper_state.py
@@ -161,9 +161,7 @@ class WrapperState(object):
                     DOM.append_child(self.stack.head().elt, wrapper_parent)
                 else:
                     # Otherwise we can append at the end of the last child.
-                    wrapper_parent = (
-                        self.stack.head().last_child
-                    )
+                    wrapper_parent = self.stack.head().last_child
 
                 DOM.append_child(wrapper_parent, new_wrapper.elt)
 

--- a/tests/test_composite_decorators.py
+++ b/tests/test_composite_decorators.py
@@ -1,7 +1,10 @@
 import re
 import unittest
 
-from draftjs_exporter.composite_decorators import render_decorators
+from draftjs_exporter.composite_decorators import (
+    render_decorators,
+    should_render_decorators,
+)
 from draftjs_exporter.constants import BLOCK_TYPES
 from draftjs_exporter.dom import DOM
 from example import LINKIFY_RE, br, hashtag, linkify
@@ -87,6 +90,17 @@ class TestBR(unittest.TestCase):
             ),
             "<br/>",
         )
+        self.assertEqual(
+            DOM.render(
+                render_decorators(
+                    [BR_DECORATOR],
+                    "test \n test",
+                    {"type": BLOCK_TYPES.UNSTYLED, "depth": 0},
+                    [],
+                )
+            ),
+            "test <br/> test",
+        )
 
     def test_render_code_block(self):
         self.assertEqual(
@@ -168,4 +182,32 @@ class TestCompositeDecorators(unittest.TestCase):
             "test https://www.example.com#hash #hashtagtest",
             blocks[0],
             blocks,
+        )
+
+    def test_should_render_decorators_empty(self):
+        self.assertEqual(
+            should_render_decorators([], "test"), False,
+        )
+
+    def test_should_render_decorators_more_than_one(self):
+        self.assertEqual(
+            should_render_decorators(
+                [HASHTAG_DECORATOR, LINKIFY_DECORATOR], "test",
+            ),
+            True,
+        )
+
+    def test_should_render_decorators_single_not_br(self):
+        self.assertEqual(
+            should_render_decorators([HASHTAG_DECORATOR], "test"), True,
+        )
+
+    def test_should_render_decorators_single_br_absent(self):
+        self.assertEqual(
+            should_render_decorators([BR_DECORATOR], "test"), False,
+        )
+
+    def test_should_render_decorators_single_br_present(self):
+        self.assertEqual(
+            should_render_decorators([BR_DECORATOR], "test \n test"), True,
         )


### PR DESCRIPTION
Changes block rendering to:

- Bypass styles rendering when there are no styles defined on the given block
- Bypass composite decorators rendering for the most common case of using `<br/>` alone

Before:

```
$ BENCHMARK_RUNS=100 make benchmark
python benchmark.py
Exporting 792 ContentStates 100 times
         48263701 function calls (45467001 primitive calls) in 29.696 seconds

   Ordered by: cumulative time
   List reduced from 71 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    79200    0.918    0.000   29.696    0.000 html.py:55(render)
   565000    2.569    0.000   21.452    0.000 html.py:86(render_block)
   565000    1.274    0.000    8.137    0.000 wrapper_state.py:99(element_for)
    79200    0.045    0.000    6.486    0.000 dom.py:119(render)
1049100/79200    1.427    0.000    6.441    0.000 string.py:88(render)
934400/79200    0.686    0.000    6.377    0.000 string.py:79(render_children)
1358400/1242000    3.164    0.000    6.281    0.000 dom.py:37(create_element)
934400/79200    1.036    0.000    6.203    0.000 string.py:83(<listcomp>)
   764500    1.219    0.000    4.501    0.000 composite_decorators.py:56(render_decorators)
  1415200    0.842    0.000    3.021    0.000 composite_decorators.py:32(apply_decorators)


Measuring memory consumption
Filename: benchmark.py

Line #    Mem usage    Increment   Line Contents
================================================
   101  42.417969 MiB  42.417969 MiB   @profile(precision=6)
   102                             def memory_consumption_run():
   103  42.421875 MiB   0.003906 MiB       exporter = HTML(config)
   104
   105  42.535156 MiB   0.000000 MiB       for content_state in content_states:
   106  42.535156 MiB   0.050781 MiB           exporter.render(content_state)
```

After:

```
$ BENCHMARK_RUNS=100 make benchmark
python benchmark.py
Exporting 792 ContentStates 100 times
         41998201 function calls (39315301 primitive calls) in 22.440 seconds

   Ordered by: cumulative time
   List reduced from 68 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    79200    0.809    0.000   22.440    0.000 html.py:56(render)
   565000    1.691    0.000   14.683    0.000 html.py:87(render_block)
   565000    1.097    0.000    7.406    0.000 wrapper_state.py:99(element_for)
    79200    0.041    0.000    6.169    0.000 dom.py:124(render)
935300/79200    1.268    0.000    6.128    0.000 string.py:88(render)
934400/79200    0.630    0.000    6.072    0.000 string.py:79(render_children)
934400/79200    0.988    0.000    5.931    0.000 string.py:83(<listcomp>)
1244600/1128200    2.814    0.000    5.585    0.000 dom.py:37(create_element)
   565000    0.434    0.000    2.769    0.000 wrapper_state.py:116(parent_for)
  1113600    0.877    0.000    2.173    0.000 __init__.py:12(escape)


Measuring memory consumption
Filename: benchmark.py

Line #    Mem usage    Increment   Line Contents
================================================
   101  42.453125 MiB  42.453125 MiB   @profile(precision=6)
   102                             def memory_consumption_run():
   103  42.457031 MiB   0.003906 MiB       exporter = HTML(config)
   104
   105  42.546875 MiB   0.000000 MiB       for content_state in content_states:
   106  42.546875 MiB   0.042969 MiB           exporter.render(content_state)
```


---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- [x] Linting passes (`make lint`)
- [x] Consider updating documentation. If you don't, tell us why.
- [x] List the environments / platforms in which you tested your changes.

Thanks for contributing to this project!
