### PR TITLE
Add wheel build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean-pyc init help test-ci
+.PHONY: build clean-pyc init help test-ci
 .DEFAULT_GOAL := help
 
 help: ## See what commands are available.
@@ -44,16 +44,11 @@ clean-pyc: ## Remove Python file artifacts.
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 
-clean-dist: ## Clean the dist folder
+build: ## Builds package version
 	rm dist/*
+	python setup.py sdist bdist_wheel
 
-sdist: ## Builds package version source distribution
-	python setup.py sdist
-
-bdist_wheel: ## Builds package version wheel distribution
-	python setup.py bdist_wheel
-
-publish: clean-dist bdist_wheel sdist ## Publishes a new version to pypi.
+publish: build ## Publishes a new version to pypi.
 	twine upload dist/* && echo 'Success! Go to https://pypi.org/project/draftjs_exporter/ and check that all is well.'
 
 publish-test: clean-dist bdist_wheel sdist ## Publishes a new version to test pypi.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## See what commands are available.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36mmake %-15s\033[0m # %s\n", $$1, $$2}'
 
 init: clean-pyc ## Install dependencies and initialise for development.
-	pip install --upgrade pip setuptools twine
+	pip install --upgrade pip setuptools wheel twine
 	pip install -e '.[testing,docs]' -U
 	nvm use
 	npm install
@@ -46,6 +46,9 @@ clean-pyc: ## Remove Python file artifacts.
 
 sdist: ## Builds package version
 	rm dist/* ; python setup.py sdist
+
+bdist_wheel: ## Builds package version
+	rm dist/* ; python setup.py bdist_wheel
 
 publish: sdist ## Publishes a new version to pypi.
 	twine upload dist/* && echo 'Success! Go to https://pypi.org/project/draftjs_exporter/ and check that all is well.'

--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,17 @@ clean-pyc: ## Remove Python file artifacts.
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 
-sdist: ## Builds package version
-	rm dist/* ; python setup.py sdist
+clean-dist: ## Clean the dist folder
+	rm dist/*
 
-bdist_wheel: ## Builds package version
-	rm dist/* ; python setup.py bdist_wheel
+sdist: ## Builds package version source distribution
+	python setup.py sdist
 
-publish: sdist ## Publishes a new version to pypi.
+bdist_wheel: ## Builds package version wheel distribution
+	python setup.py bdist_wheel
+
+publish: clean-dist bdist_wheel sdist ## Publishes a new version to pypi.
 	twine upload dist/* && echo 'Success! Go to https://pypi.org/project/draftjs_exporter/ and check that all is well.'
 
-publish-test: sdist ## Publishes a new version to test pypi.
+publish-test: clean-dist bdist_wheel sdist ## Publishes a new version to test pypi.
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/* && echo 'Success! Go to https://test.pypi.org/project/draftjs_exporter/ and check that all is well.'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,6 +44,7 @@ make dev             # Restarts the example whenever a file changes.
 make benchmark       # Runs a one-off performance (speed, memory) benchmark.
 make clean-pyc       # Remove Python file artifacts.
 make sdist           # Builds package version
+make bdist_wheel     # Builds package version wheel.
 make publish         # Publishes a new version to pypi.
 make publish-test    # Publishes a new version to test pypi.
 ```


### PR DESCRIPTION
fixes #132 

The primary purpose of this PR is to add an `make bdist_wheel` command to build a python wheel archive. This task is included in both the `make publish` and `make publish-test` commands and does not replace source distributions.

I've added a `make clean-dist` command to clean the dist folder. This command is ran before publishing to make sure we have a clean dist folder.

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- [x] ~~Consider adding unit tests, especially for bug fixes. If you don't, tell us why.~~
- not applicable.
- [ ] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- two failed tests but probably related to my dev environment (python 3.8.3, fedora 32)
  - FAIL: test_export_lxml_big_content_export (tests.test_exports.TestExportsLXML)
  - FAIL: test_export_lxml_entity_with_data-* (tests.test_exports.TestExportsLXML)
- [x] Linting passes (`make lint`)
- check! ✅
- [x] Consider updating documentation. If you don't, tell us why.
- [x] List the environments / platforms in which you tested your changes.
- Python 3.8; Linux Fedora 32