### PR TITLE
Tentative support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ jobs:
       env: TOXENV=py37-lower_bound_deps
     - python: 3.8
       env: TOXENV=py38-lower_bound_deps
-    - python: 3.9-dev
-      env: TOXENV=py39-lower_bound_deps
     - python: 3.6
       env: TOXENV=py36-upper_bound_deps
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ jobs:
       env: TOXENV=py37-lower_bound_deps
     - python: 3.8
       env: TOXENV=py38-lower_bound_deps
+    - python: 3.9-dev
+      env: TOXENV=py39-lower_bound_deps
     - python: 3.6
       env: TOXENV=py36-upper_bound_deps
     - python: 3.7
       env: TOXENV=py37-upper_bound_deps
     - python: 3.8
       env: TOXENV=py38-upper_bound_deps
+    - python: 3.9-dev
+      env: TOXENV=py39-upper_bound_deps
     - python: 3.8
       install:
         - pip install -e '.[testing]'

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ format: ## Format project files.
 	npm run format
 
 test: ## Test the project.
-	python -m unittest discover
+	python -X dev -W error -m unittest discover
 
 test-watch: ## Restarts the tests whenever a file changes.
 	nodemon -q -e py -w tests -w draftjs_exporter  -x "clear && make test -s || true"
@@ -34,7 +34,7 @@ test-ci: ## Continuous integration test suite.
 	tox
 
 dev: ## Restarts the example whenever a file changes.
-	nodemon -q -e py -w tests -w draftjs_exporter -w example.py  -x "clear && python example.py || true"
+	nodemon -q -e py -w tests -w draftjs_exporter -w example.py  -x "clear && python -X dev -W error example.py || true"
 
 benchmark: ## Runs a one-off performance (speed, memory) benchmark.
 	python benchmark.py

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,11 +22,12 @@ virtualenv .venv
 source ./.venv/bin/activate
 make init
 # Install required Python versions
-pyenv install --skip-existing 3.6.3
-pyenv install --skip-existing 3.7.0
-pyenv install --skip-existing 3.8.0
+pyenv install --skip-existing 3.6.11
+pyenv install --skip-existing 3.7.8
+pyenv install --skip-existing 3.8.5
+pyenv install --skip-existing 3.9.0b5
 # Make required Python versions available globally.
-pyenv global system 3.6.3 3.7.0 3.8.0
+pyenv global system 3.6.11 3.7.8 3.8.5 3.9.0b5
 ```
 
 ### Commands

--- a/example.py
+++ b/example.py
@@ -108,7 +108,7 @@ def block_fallback(props: Props) -> Element:
     type_ = props["block"]["type"]
 
     if type_ == "example-discard":
-        logging.warn(
+        logging.warning(
             f'Missing config for "{type_}". Discarding block, keeping content.'
         )
         # Directly return the block's children to keep its content.
@@ -118,7 +118,7 @@ def block_fallback(props: Props) -> Element:
         # Return None to not render anything, removing the whole block.
         return None
     else:
-        logging.warn(f'Missing config for "{type_}". Using div instead.')
+        logging.warning(f'Missing config for "{type_}". Using div instead.')
         # Provide a fallback.
         return DOM.create_element("div", {}, props["children"])
 
@@ -126,7 +126,7 @@ def block_fallback(props: Props) -> Element:
 def entity_fallback(props: Props) -> Element:
     type_ = props["entity"]["type"]
     key = props["entity"]["entity_range"]["key"]
-    logging.warn(f'Missing config for "{type_}", key "{key}".')
+    logging.warning(f'Missing config for "{type_}", key "{key}".')
     return DOM.create_element(
         "span", {"class": "missing-entity"}, props["children"]
     )
@@ -134,7 +134,7 @@ def entity_fallback(props: Props) -> Element:
 
 def style_fallback(props: Props) -> Element:
     type_ = props["inline_style_range"]["style"]
-    logging.warn(f'Missing config for "{type_}". Deleting style.')
+    logging.warning(f'Missing config for "{type_}". Deleting style.')
     return props["children"]
 
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Internet :: WWW/HTTP :: Site Management",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from draftjs_exporter import __version__
 dependencies = {
     # Keep this in sync with the dependencies in tox.ini.
     "lxml": ["lxml>=4.2.0,<5"],
-    "html5lib": ["beautifulsoup4>=4.4.1,<5", "html5lib>=0.999,<=1.0.1"],
+    "html5lib": ["beautifulsoup4>=4.4.1,<5", "html5lib>=0.999,<=2"],
     "docs": [],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 usedevelop = True
-envlist = py{36,37,38,39}-{lower_bound_deps,upper_bound_deps}
+envlist = py{36,37,38}-{lower_bound_deps,upper_bound_deps}, py39-upper_bound_deps
 
 [testenv]
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 usedevelop = True
-envlist = py{36,37,38}-{lower_bound_deps,upper_bound_deps}
+envlist = py{36,37,38,39}-{lower_bound_deps,upper_bound_deps}
 
 [testenv]
 whitelist_externals = make
@@ -15,6 +15,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 
 deps =
     # Keep this in sync with the dependencies in setup.py.

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     lower_bound_deps: html5lib==0.999
     lower_bound_deps: lxml==4.2.0
     upper_bound_deps: beautifulsoup4<5
-    upper_bound_deps: html5lib<=1.0.1
+    upper_bound_deps: html5lib<=2
     upper_bound_deps: lxml<4.4.0
 
 commands =


### PR DESCRIPTION
This updates the library’s test suite and package metadata to check for Python [3.9 support](https://docs.python.org/3.9/whatsnew/3.9.html). No code changes needed – but there were a few deprecation warnings in `html5lib`, and in the example code. This should make it easier to support Python 3.10 in late 2021.

---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- ~[ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.~ N/A
- [ ] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- [x] Linting passes (`make lint`)
- [x] Consider updating documentation. If you don't, tell us why.
- [x] List the environments / platforms in which you tested your changes. Python 3.9.0b5
