### PR TITLE
Release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## Unreleased
 
+## [v4.1.1](https://github.com/springload/draftjs_exporter/releases/tag/v4.1.1)
+
+### Changed
+
+- Add support for Python 3.9 ([#134](https://github.com/springload/draftjs_exporter/pull/134)).
+- Update html5lib upper bound, now defined as `html5lib>=0.999,<2`, to ensure compatibility with Python 3.10 ([#134](https://github.com/springload/draftjs_exporter/pull/134)).
+
 ## [v4.1.0](https://github.com/springload/draftjs_exporter/releases/tag/v4.1.0)
 
 ### Added

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "draftjs_exporter"
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 __author__ = "Springload"
 __license__ = "MIT"
 __copyright__ = "Copyright 2016-present Springload"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from draftjs_exporter import __version__
 dependencies = {
     # Keep this in sync with the dependencies in tox.ini.
     "lxml": ["lxml>=4.2.0,<5"],
-    "html5lib": ["beautifulsoup4>=4.4.1,<5", "html5lib>=0.999,<=2"],
+    "html5lib": ["beautifulsoup4>=4.4.1,<5", "html5lib>=0.999,<2"],
     "docs": [],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     lower_bound_deps: html5lib==0.999
     lower_bound_deps: lxml==4.2.0
     upper_bound_deps: beautifulsoup4<5
-    upper_bound_deps: html5lib<=2
+    upper_bound_deps: html5lib<2
     upper_bound_deps: lxml<4.4.0
 
 commands =


### PR DESCRIPTION
## [v4.1.1](https://github.com/springload/draftjs_exporter/releases/tag/v4.1.1)

### Changed

- Add support for Python 3.9 ([#134](https://github.com/springload/draftjs_exporter/pull/134)).
- Update html5lib upper bound, now defined as `html5lib>=0.999,<2`, to ensure compatibility with Python 3.10 ([#134](https://github.com/springload/draftjs_exporter/pull/134)).