### PR TITLE
Add new "string_compat" engine for maximum output stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,17 @@ See `examples.py` in the repository for more details.
 
 ### Alternative backing engines
 
-By default, the exporter uses a dependency-free engine called `string` to build the DOM tree. There are two alternative backing engines: `html5lib` (via BeautifulSoup) and `lxml`.
+By default, the exporter uses a dependency-free engine called `string` to build the DOM tree. There are alternatives:
+
+- `html5lib` (via BeautifulSoup)
+- `lxml`.
+- `string_compat` (A variant of `string` with no backwards-incompatible changes since its first release).
 
 The `string` engine is the fastest, and does not have any dependencies. Its only drawback is that the `parse_html` method does not escape/sanitise HTML like that of other engines.
 
 - For `html5lib`, do `pip install draftjs_exporter[html5lib]`.
 - For `lxml`, do `pip install draftjs_exporter[lxml]`. It also requires `libxml2` and `libxslt` to be available on your system.
+- There are no additional dependencies for `string_compat`.
 
 Then, use the `engine` attribute of the exporter config:
 
@@ -254,6 +259,8 @@ config = {
     'engine': DOM.HTML5LIB,
     # Or for lxml:
     'engine': DOM.LXML,
+    # Or to use the "maximum stability" string_compat engine:
+    'engine': DOM.STRING_COMPAT,
 }
 ```
 

--- a/draftjs_exporter/dom.py
+++ b/draftjs_exporter/dom.py
@@ -18,6 +18,7 @@ class DOM:
     HTML5LIB = "draftjs_exporter.engines.html5lib.DOM_HTML5LIB"
     LXML = "draftjs_exporter.engines.lxml.DOM_LXML"
     STRING = "draftjs_exporter.engines.string.DOMString"
+    STRING_COMPAT = "draftjs_exporter.engines.string_compat.DOMStringCompat"
 
     dom: DOMEngine = None  # type: ignore
 

--- a/draftjs_exporter/engines/string_compat.py
+++ b/draftjs_exporter/engines/string_compat.py
@@ -1,0 +1,69 @@
+from html import escape
+from typing import Sequence, Union
+
+from draftjs_exporter.engines.base import Attr
+from draftjs_exporter.engines.string import DOMString, Elt, VOID_ELEMENTS
+from draftjs_exporter.types import HTML
+
+
+class DOMStringCompat(DOMString):
+    """
+    The same as DOMString, but with as much backwards-compatibility as possible.
+    """
+
+    @staticmethod
+    def render_attrs(attr: Attr) -> str:
+        attrs = [f' {k}="{escape(v)}"' for k, v in attr.items()]
+        # Compat: reverts "Remove HTML attributes alphabetical sorting of default string engine ([#129](https://github.com/springload/draftjs_exporter/pull/129))"
+        attrs.sort()
+        return "".join(attrs)
+
+    @staticmethod
+    def render_children(children: Sequence[Union[HTML, Elt]]) -> HTML:
+        return "".join(
+            [
+                DOMStringCompat.render(c) if isinstance(c, Elt)
+                # Compat: reverts "Disable single and double quotes escaping outside of attributes for string engine ([#129](https://github.com/springload/draftjs_exporter/pull/129))"
+                else escape(c, quote=True)
+                for c in children
+            ]
+        )
+
+    @staticmethod
+    def render(elt: Elt) -> HTML:
+        type_ = elt.type
+        attr = DOMStringCompat.render_attrs(elt.attr) if elt.attr else ""
+        children = (
+            DOMStringCompat.render_children(elt.children)
+            if elt.children
+            else ""
+        )
+
+        if type_ == "fragment":
+            return children
+
+        if type_ in VOID_ELEMENTS:
+            return f"<{type_}{attr}/>"
+
+        if type_ == "escaped_html":
+            return elt.markup  # type: ignore
+
+        return f"<{type_}{attr}>{children}</{type_}>"
+
+    @staticmethod
+    def render_debug(elt: Elt) -> HTML:
+        type_ = elt.type
+        attr = DOMStringCompat.render_attrs(elt.attr) if elt.attr else ""
+        children = (
+            DOMStringCompat.render_children(elt.children)
+            if elt.children
+            else ""
+        )
+
+        if type_ in VOID_ELEMENTS:
+            return f"<{type_}{attr}/>"
+
+        if type_ == "escaped_html":
+            return elt.markup  # type: ignore
+
+        return f"<{type_}{attr}>{children}</{type_}>"

--- a/tests/engines/test_engines_string_compat.py
+++ b/tests/engines/test_engines_string_compat.py
@@ -1,11 +1,11 @@
 import unittest
 
-from draftjs_exporter.engines.string import DOMString
+from draftjs_exporter.engines.string_compat import DOMStringCompat
 
-S = DOMString
+S = DOMStringCompat
 
 
-class TestDOMString(unittest.TestCase):
+class TestDOMStringCompat(unittest.TestCase):
     def test_create_tag(self):
         self.assertEqual(
             S.render_debug(S.create_tag("p", {"class": "intro"})),
@@ -46,6 +46,18 @@ class TestDOMString(unittest.TestCase):
             ' alt="img&#x27;s alt" class="intro &quot; text" src="src.png"',
         )
 
+    def test_render_attrs_sorting(self):
+        self.assertEqual(
+            S.render_attrs(
+                {
+                    "class": 'intro " text',
+                    "src": "src.png",
+                    "alt": "img's alt",
+                }
+            ),
+            ' alt="img&#x27;s alt" class="intro &quot; text" src="src.png"',
+        )
+
     def test_render_children(self):
         self.assertEqual(
             S.render_children(
@@ -55,7 +67,7 @@ class TestDOMString(unittest.TestCase):
                     'double " quote',
                 ]
             ),
-            'single \' quote<p class="intro"></p>double " quote',
+            'single &#x27; quote<p class="intro"></p>double &quot; quote',
         )
 
     def test_render(self):

--- a/tests/test_exports.json
+++ b/tests/test_exports.json
@@ -4,7 +4,8 @@
     "output": {
       "html5lib": "<p>a</p>",
       "lxml": "<p>a</p>",
-      "string": "<p>a</p>"
+      "string": "<p>a</p>",
+      "string_compat": "<p>a</p>"
     },
     "content_state": {
       "entityMap": {},
@@ -26,7 +27,8 @@
     "output": {
       "html5lib": "<p>asd<strong>f</strong></p>",
       "lxml": "<p>asd<strong>f</strong></p>",
-      "string": "<p>asd<strong>f</strong></p>"
+      "string": "<p>asd<strong>f</strong></p>",
+      "string_compat": "<p>asd<strong>f</strong></p>"
     },
     "content_state": {
       "entityMap": {},
@@ -54,7 +56,8 @@
     "output": {
       "html5lib": "<p><strong><em>BoldItalic</em></strong></p>",
       "lxml": "<p><strong><em>BoldItalic</em></strong></p>",
-      "string": "<p><strong><em>BoldItalic</em></strong></p>"
+      "string": "<p><strong><em>BoldItalic</em></strong></p>",
+      "string_compat": "<p><strong><em>BoldItalic</em></strong></p>"
     },
     "content_state": {
       "entityMap": {},
@@ -87,7 +90,8 @@
     "output": {
       "html5lib": "<p><strong><em>ItalicBold</em></strong></p>",
       "lxml": "<p><strong><em>ItalicBold</em></strong></p>",
-      "string": "<p><strong><em>ItalicBold</em></strong></p>"
+      "string": "<p><strong><em>ItalicBold</em></strong></p>",
+      "string_compat": "<p><strong><em>ItalicBold</em></strong></p>"
     },
     "content_state": {
       "entityMap": {},
@@ -120,7 +124,8 @@
     "output": {
       "html5lib": "<p><em>Bold</em><strong>Italic</strong></p>",
       "lxml": "<p><em>Bold</em><strong>Italic</strong></p>",
-      "string": "<p><em>Bold</em><strong>Italic</strong></p>"
+      "string": "<p><em>Bold</em><strong>Italic</strong></p>",
+      "string_compat": "<p><em>Bold</em><strong>Italic</strong></p>"
     },
     "content_state": {
       "entityMap": {},
@@ -153,7 +158,8 @@
     "output": {
       "html5lib": "<p><a href=\"https://google.com\">G</a><a href=\"https://facebook.com\">F</a></p>",
       "lxml": "<p><a href=\"https://google.com\">G</a><a href=\"https://facebook.com\">F</a></p>",
-      "string": "<p><a href=\"https://google.com\">G</a><a href=\"https://facebook.com\">F</a></p>"
+      "string": "<p><a href=\"https://google.com\">G</a><a href=\"https://facebook.com\">F</a></p>",
+      "string_compat": "<p><a href=\"https://google.com\">G</a><a href=\"https://facebook.com\">F</a></p>"
     },
     "content_state": {
       "blocks": [
@@ -202,7 +208,8 @@
     "output": {
       "html5lib": "<p><strong>0</strong><code>1</code><em>2</em><u>3</u><s>4</s><sup>5</sup><sub>6</sub><mark>7</mark><q>8</q><small>9</small><samp>a</samp><ins>b</ins><del>c</del><kbd>d</kbd>ef</p>",
       "lxml": "<p><strong>0</strong><code>1</code><em>2</em><u>3</u><s>4</s><sup>5</sup><sub>6</sub><mark>7</mark><q>8</q><small>9</small><samp>a</samp><ins>b</ins><del>c</del><kbd>d</kbd>ef</p>",
-      "string": "<p><strong>0</strong><code>1</code><em>2</em><u>3</u><s>4</s><sup>5</sup><sub>6</sub><mark>7</mark><q>8</q><small>9</small><samp>a</samp><ins>b</ins><del>c</del><kbd>d</kbd>ef</p>"
+      "string": "<p><strong>0</strong><code>1</code><em>2</em><u>3</u><s>4</s><sup>5</sup><sub>6</sub><mark>7</mark><q>8</q><small>9</small><samp>a</samp><ins>b</ins><del>c</del><kbd>d</kbd>ef</p>",
+      "string_compat": "<p><strong>0</strong><code>1</code><em>2</em><u>3</u><s>4</s><sup>5</sup><sub>6</sub><mark>7</mark><q>8</q><small>9</small><samp>a</samp><ins>b</ins><del>c</del><kbd>d</kbd>ef</p>"
     },
     "content_state": {
       "entityMap": {},
@@ -295,7 +302,8 @@
     "output": {
       "html5lib": "<p><a href=\"/\" title=\"hi\"><em>a</em></a></p>",
       "lxml": "<p><a href=\"/\" title=\"hi\"><em>a</em></a></p>",
-      "string": "<p><a href=\"/\" title=\"hi\"><em>a</em></a></p>"
+      "string": "<p><a href=\"/\" title=\"hi\"><em>a</em></a></p>",
+      "string_compat": "<p><a href=\"/\" title=\"hi\"><em>a</em></a></p>"
     },
     "content_state": {
       "entityMap": {
@@ -339,7 +347,8 @@
     "output": {
       "html5lib": "<p><a data-=\"no\" data-False=\"bad\" data-id=\"42\" data-mutability=\"mutable\" extra=\"foo\" href=\"/\" title=\"hi\"><em>a</em></a></p>",
       "lxml": "<p><a href=\"/\" title=\"hi\" extra=\"foo\" data-id=\"42\" data-mutability=\"mutable\" data-False=\"bad\" data-=\"no\"><em>a</em></a></p>",
-      "string": "<p><a href=\"/\" title=\"hi\" extra=\"foo\" data-id=\"42\" data-mutability=\"mutable\" data-False=\"bad\" data-=\"no\"><em>a</em></a></p>"
+      "string": "<p><a href=\"/\" title=\"hi\" extra=\"foo\" data-id=\"42\" data-mutability=\"mutable\" data-False=\"bad\" data-=\"no\"><em>a</em></a></p>",
+      "string_compat": "<p><a data-=\"no\" data-False=\"bad\" data-id=\"42\" data-mutability=\"mutable\" extra=\"foo\" href=\"/\" title=\"hi\"><em>a</em></a></p>"
     },
     "content_state": {
       "entityMap": {
@@ -387,7 +396,8 @@
     "output": {
       "html5lib": "<p><a href=\"/\"><em>a</em></a></p>",
       "lxml": "<p><a href=\"/\"><em>a</em></a></p>",
-      "string": "<p><a href=\"/\"><em>a</em></a></p>"
+      "string": "<p><a href=\"/\"><em>a</em></a></p>",
+      "string_compat": "<p><a href=\"/\"><em>a</em></a></p>"
     },
     "content_state": {
       "entityMap": {
@@ -429,7 +439,8 @@
     "output": {
       "html5lib": "<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>",
       "lxml": "<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>",
-      "string": "<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>"
+      "string": "<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>",
+      "string_compat": "<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>"
     },
     "content_state": {
       "entityMap": {},
@@ -467,7 +478,8 @@
     "output": {
       "html5lib": "<h2>Title 2</h2><h3>Title 3</h3><h4>Title 4</h4><h5>Title 5</h5><blockquote>Blockquote</blockquote><ul class=\"bullet-list\"><li>List item<ul class=\"bullet-list\"><li>Nested list item</li></ul></li></ul><ol><li>Ordered item <strong>(bold)</strong><ol><li>Nested ordered item <em>(italic)</em></li></ol></li></ol>",
       "lxml": "<h2>Title 2</h2><h3>Title 3</h3><h4>Title 4</h4><h5>Title 5</h5><blockquote>Blockquote</blockquote><ul class=\"bullet-list\"><li>List item<ul class=\"bullet-list\"><li>Nested list item</li></ul></li></ul><ol><li>Ordered item <strong>(bold)</strong><ol><li>Nested ordered item <em>(italic)</em></li></ol></li></ol>",
-      "string": "<h2>Title 2</h2><h3>Title 3</h3><h4>Title 4</h4><h5>Title 5</h5><blockquote>Blockquote</blockquote><ul class=\"bullet-list\"><li>List item<ul class=\"bullet-list\"><li>Nested list item</li></ul></li></ul><ol><li>Ordered item <strong>(bold)</strong><ol><li>Nested ordered item <em>(italic)</em></li></ol></li></ol>"
+      "string": "<h2>Title 2</h2><h3>Title 3</h3><h4>Title 4</h4><h5>Title 5</h5><blockquote>Blockquote</blockquote><ul class=\"bullet-list\"><li>List item<ul class=\"bullet-list\"><li>Nested list item</li></ul></li></ul><ol><li>Ordered item <strong>(bold)</strong><ol><li>Nested ordered item <em>(italic)</em></li></ol></li></ol>",
+      "string_compat": "<h2>Title 2</h2><h3>Title 3</h3><h4>Title 4</h4><h5>Title 5</h5><blockquote>Blockquote</blockquote><ul class=\"bullet-list\"><li>List item<ul class=\"bullet-list\"><li>Nested list item</li></ul></li></ul><ol><li>Ordered item <strong>(bold)</strong><ol><li>Nested ordered item <em>(italic)</em></li></ol></li></ol>"
     },
     "content_state": {
       "entityMap": {},
@@ -555,7 +567,8 @@
     "output": {
       "html5lib": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><img src=\"http://placekitten.com/500/300\"/>:)<p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>",
       "lxml": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><img src=\"http://placekitten.com/500/300\">:)<p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>",
-      "string": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><img src=\"http://placekitten.com/500/300\"/>:)<p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>"
+      "string": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><img src=\"http://placekitten.com/500/300\"/>:)<p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>",
+      "string_compat": "<h2>DraftJS AST Exporter</h2><p>In your draft-js, <strong>exporting</strong> your <em>content</em>:</p><ol><li>From draft-js internals</li><li>To an abstract syntax tree</li><li>Extensibility.</li></ol><img src=\"http://placekitten.com/500/300\"/>:)<p>Find the project on <a href=\"https://github.com/icelab/draft-js-ast-exporter\">Github</a>.</p>"
     },
     "content_state": {
       "entityMap": {
@@ -666,7 +679,8 @@
     "output": {
       "html5lib": "<p><a href=\"http://www.example.com/?a=1&amp;b=2\">http://www.example.com/?a=1&amp;b=2</a></p>",
       "lxml": "<p><a href=\"http://www.example.com/?a=1&amp;b=2\">http://www.example.com/?a=1&amp;b=2</a></p>",
-      "string": "<p><a href=\"http://www.example.com/?a=1&amp;b=2\">http://www.example.com/?a=1&amp;b=2</a></p>"
+      "string": "<p><a href=\"http://www.example.com/?a=1&amp;b=2\">http://www.example.com/?a=1&amp;b=2</a></p>",
+      "string_compat": "<p><a href=\"http://www.example.com/?a=1&amp;b=2\">http://www.example.com/?a=1&amp;b=2</a></p>"
     },
     "content_state": {
       "entityMap": {
@@ -702,7 +716,8 @@
     "output": {
       "html5lib": "<p>search <a href=\"http://www.google.com#world\">http://www.google.com#world</a> for the <span class=\"hashtag\">#world</span></p>",
       "lxml": "<p>search <a href=\"http://www.google.com#world\">http://www.google.com#world</a> for the <span class=\"hashtag\">#world</span></p>",
-      "string": "<p>search <a href=\"http://www.google.com#world\">http://www.google.com#world</a> for the <span class=\"hashtag\">#world</span></p>"
+      "string": "<p>search <a href=\"http://www.google.com#world\">http://www.google.com#world</a> for the <span class=\"hashtag\">#world</span></p>",
+      "string_compat": "<p>search <a href=\"http://www.google.com#world\">http://www.google.com#world</a> for the <span class=\"hashtag\">#world</span></p>"
     },
     "content_state": {
       "entityMap": {},
@@ -722,9 +737,10 @@
   {
     "label": "Big content export",
     "output": {
-      "html5lib": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by running this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React's <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr/><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br/>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img alt=\"Test image alt text\" height=\"200\" src=\"https://placekitten.com/g/300/200\" width=\"300\"/><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props['block']['data']\n    return DOM.create_element('blockquote', {\n        'cite': block_data.get('cite')\n    }, props['children'])\n</code></pre><p>Voilà!</p>",
-      "lxml": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by running this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React's <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img src=\"https://placekitten.com/g/300/200\" width=\"300\" height=\"200\" alt=\"Test image alt text\"><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props['block']['data']\n    return DOM.create_element('blockquote', {\n        'cite': block_data.get('cite')\n    }, props['children'])\n</code></pre><p>Voilà!</p>",
-      "string": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by running this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React's <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr/><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br/>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img src=\"https://placekitten.com/g/300/200\" width=\"300\" height=\"200\" alt=\"Test image alt text\"/><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props['block']['data']\n    return DOM.create_element('blockquote', {\n        'cite': block_data.get('cite')\n    }, props['children'])\n</code></pre><p>Voilà!</p>"
+      "html5lib": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by \"running\" this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React's <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr/><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br/>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img alt=\"Test image alt text\" height=\"200\" src=\"https://placekitten.com/g/300/200\" width=\"300\"/><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props['block']['data']\n    return DOM.create_element('blockquote', {\n        'cite': block_data.get('cite')\n    }, props['children'])\n</code></pre><p>Voilà!</p>",
+      "lxml": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by \"running\" this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React's <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img src=\"https://placekitten.com/g/300/200\" width=\"300\" height=\"200\" alt=\"Test image alt text\"><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props['block']['data']\n    return DOM.create_element('blockquote', {\n        'cite': block_data.get('cite')\n    }, props['children'])\n</code></pre><p>Voilà!</p>",
+      "string": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by \"running\" this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React's <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr/><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br/>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img src=\"https://placekitten.com/g/300/200\" width=\"300\" height=\"200\" alt=\"Test image alt text\"/><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props['block']['data']\n    return DOM.create_element('blockquote', {\n        'cite': block_data.get('cite')\n    }, props['children'])\n</code></pre><p>Voilà!</p>",
+      "string_compat": "<h2>draftjs_exporter is an HTML exporter for <a href=\"https://github.com/facebook/draft-js\">Draft.js</a> content</h2><blockquote>Try it out by &quot;running&quot; this file!</blockquote><h3>Features 📝🍸</h3><p>The exporter aims to provide sensible defaults from basic block types and inline styles to HTML, that can easily be customised when required. For more advanced scenarios, an API is provided (mimicking React&#x27;s <a href=\"https://facebook.github.io/react/docs/top-level-api.html#react.createelement\"><code>createElement</code></a>) to create custom rendering components of arbitrary complexity.</p><hr/><p>Here are some features worth highlighting:</p><ul class=\"bullet-list\"><li>Convert line breaks to <code>&lt;br&gt;</code><br/>elements.</li><li>Automatic conversion of entity data to HTML attributes (int &amp; boolean to string, <a href=\"https://facebook.github.io/react/docs/jsx-in-depth.html\"><code>style object</code> to <code>style string</code></a>).</li><li>Wrapped blocks (<code>&lt;li&gt; </code>elements go inside <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code>).<ul class=\"bullet-list\"><li>With arbitrary nesting.<ul class=\"bullet-list\"><li>Common text styles: <strong>Bold</strong>, <em>Italic</em>, <u>Underline</u>, <code>Monospace</code>, <s>Strikethrough.</s> <kbd>cmd + b</kbd></li><li><s>Overlapping </s><strong><s>te</s></strong><strong><em>xt</em></strong><em> styles. </em><strong style=\"text-decoration: underline;\">Custom styles</strong> too!<ul class=\"bullet-list\"><li><span class=\"hashtag\">#hashtag</span> support via <a href=\"https://github.com/springload/draftjs_exporter/pull/17\">#CompositeDecorators</a>.<ul class=\"bullet-list\"><li>Linkify URLs too! <a href=\"http://example.com/\">http://example.com/</a></li></ul></li></ul></li><li>Depth can go back and forth, it works fiiine (1)</li></ul></li><li>Depth can go back and forth, it works fiiine (2)<ul class=\"bullet-list\"><li>Depth can go back and forth, it works fiiine (3)</li></ul></li><li>Depth can go back and forth, it works fiiine (4)</li></ul></li><li>Depth can go back and forth, it works fiiine (5)</li></ul><img alt=\"Test image alt text\" height=\"200\" src=\"https://placekitten.com/g/300/200\" width=\"300\"/><h3>For developers \ud83d\ude80</h3><ol><li>Import the library</li><li>Define your configuration</li><li>Go!<ol><li>Optionally, define your custom components.</li></ol></li></ol><pre><code>def Blockquote(props):\n    block_data = props[&#x27;block&#x27;][&#x27;data&#x27;]\n    return DOM.create_element(&#x27;blockquote&#x27;, {\n        &#x27;cite&#x27;: block_data.get(&#x27;cite&#x27;)\n    }, props[&#x27;children&#x27;])\n</code></pre><p>Voilà!</p>"
     },
     "content_state": {
       "entityMap": {
@@ -808,7 +824,7 @@
         },
         {
           "key": "74al",
-          "text": "Try it out by running this file!",
+          "text": "Try it out by \"running\" this file!",
           "type": "blockquote",
           "depth": 0,
           "inlineStyleRanges": [],
@@ -1187,7 +1203,8 @@
     "output": {
       "html5lib": "<p>a</p><p>a</p>",
       "lxml": "<p>a</p><p>a</p>",
-      "string": "<p>a</p><p>a</p>"
+      "string": "<p>a</p><p>a</p>",
+      "string_compat": "<p>a</p><p>a</p>"
     },
     "content_state": {
       "entityMap": {},

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -115,13 +115,27 @@ class TestExportsLXML(unittest.TestCase, metaclass=TestExportsMeta):
         Stats(cls.pr).strip_dirs().sort_stats("cumulative").print_stats(0)
 
 
-class TestExportsSTRING(unittest.TestCase, metaclass=TestExportsMeta):
+class TestExportsString(unittest.TestCase, metaclass=TestExportsMeta):
     @classmethod
     def setUpClass(cls):
         DOM.use(DOM.STRING)
         cls.pr = cProfile.Profile()
         cls.pr.enable()
         print("\nstring")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.pr.disable()
+        Stats(cls.pr).strip_dirs().sort_stats("cumulative").print_stats(0)
+
+
+class TestExportsString_Compat(unittest.TestCase, metaclass=TestExportsMeta):
+    @classmethod
+    def setUpClass(cls):
+        DOM.use(DOM.STRING_COMPAT)
+        cls.pr = cProfile.Profile()
+        cls.pr.enable()
+        print("\nstring_compat")
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This introduces a new `string_compat` / `draftjs_exporter.engines.string_compat.DOMStringCompat` engine, which is a copy of the existing `string` engine with two changes added for backwards compatibility:

- Reverts _Remove HTML attributes alphabetical sorting of default string engine ([#129](https://github.com/springload/draftjs_exporter/pull/129))_.
- Reverts _Disable single and double quotes escaping outside of attributes for string engine ([#129](https://github.com/springload/draftjs_exporter/pull/129))_.

Both of those changes were introduced in v4.0.0, I think they make complete sense for projects using the exporter since, but they do change the output. It’s important for the output to be as stable as possible in a lot of scenarios, so I made sure to document how to preserve the output back then.

Rethinking this a bit, I think it makes a lot of sense to actually have built-in support for this, so people for whom output stability is more important than speed have this kind of guarantee. It’s also nicer to maintain as a copy of the code in the same branch rather than backporting speedups to older versions indefinitely.

I had also considered adding those exact options to the string engine directly, but decided no to in the end – if there are more such compatibility changes needed in the future, I think it would be nicer for the two engines to be able to diverge as much as possible, rather than have the same code paths with different configuration.

---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- [x] Linting passes (`make lint`)
- [x] Consider updating documentation. If you don't, tell us why.
- [x] List the environments / platforms in which you tested your changes. macOS Python 3.10.