### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ def block_fallback(props):
     type_ = props['block']['type']
 
     if type_ == 'example-discard':
-        logging.warn(f'Missing config for "{type_}". Discarding block, keeping content.')
+        logging.warning(f'Missing config for "{type_}". Discarding block, keeping content.')
         # Directly return the block's children to keep its content.
         return props['children']
     elif type_ == 'example-delete':
@@ -230,7 +230,7 @@ def block_fallback(props):
         # Return None to not render anything, removing the whole block.
         return None
     else:
-        logging.warn(f'Missing config for "{type_}". Using div instead.')
+        logging.warning(f'Missing config for "{type_}". Using div instead.')
         # Provide a fallback.
         return DOM.create_element('div', {}, props['children'])
 ```

--- a/benchmark.py
+++ b/benchmark.py
@@ -29,7 +29,7 @@ def link(props):
 def block_fallback(props):
     type_ = props["block"]["type"]
 
-    logging.warn(f'Missing config for "{type_}".')
+    logging.warning(f'Missing config for "{type_}".')
     return DOM.create_element("div", {}, props["children"])
 
 


### PR DESCRIPTION
<!-- See the general contribution guidelines in docs/CONTRIBUTING.md -->


Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444

<!-- If your pull request is for a specific ticket, this is a good place to link to it. -->

---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.

Replacing deprecated function with one which has been around since 2.3.

- [x] All new and existing tests pass, with 100% test coverage (`make test-coverage`)
- [x] Linting passes (`make lint`)
- [x] Consider updating documentation. If you don't, tell us why.

Not big enough for docs.

- [x] List the environments / platforms in which you tested your changes.

macOS / Python 3.10

Thanks for contributing to this project!

