### PR TITLE
Add tests for global DOM engine behavior

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -224,3 +224,21 @@ class TestHTML(unittest.TestCase):
             ),
             "<h1>Header</h1>",
         )
+
+    def test_engine_is_global_for_existing_instances(self):
+        html_string = HTML({"engine": DOM.STRING})
+        HTML({"engine": DOM.STRING_COMPAT})
+
+        self.assertEqual(
+            html_string.render({"entityMap": {}, "blocks": [{"text": 'Quote "here"'}]}),
+            "<p>Quote &quot;here&quot;</p>",
+        )
+
+    def test_engine_switching_affects_previous_instance(self):
+        html_compat = HTML({"engine": DOM.STRING_COMPAT})
+        HTML({"engine": DOM.STRING})
+
+        self.assertEqual(
+            html_compat.render({"entityMap": {}, "blocks": [{"text": 'Quote "here"'}]}),
+            '<p>Quote "here"</p>',
+        )


### PR DESCRIPTION
### Motivation
- The DOM engine selection is stored on `DOM.dom` and `HTML.__init__` calls `DOM.use`, causing the engine to be global across all `HTML` instances and leading to surprising last-wins and thread-safety issues.
- Add unit tests that capture the current (problematic) behavior so future fixes can be validated with regressions. 

### Description
- Added two unit tests to `tests/test_html.py`: `test_engine_is_global_for_existing_instances` and `test_engine_switching_affects_previous_instance` that exercise engine selection across multiple `HTML` instances.
- The tests assert the difference in escaping behavior between `DOM.STRING` and `DOM.STRING_COMPAT` to demonstrate that switching engines affects previously created `HTML` instances. 

### Testing
- No automated tests were executed as part of this change; the new tests were added but not run here. 
- To run the tests locally, execute `make test` or `pytest tests/test_html.py::TestHTML::test_engine_is_global_for_existing_instances tests/test_html.py::TestHTML::test_engine_switching_affects_previous_instance`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd66bafbc83309d27bdb05b25d24a)